### PR TITLE
[DP5-RC20][U1] Harden ingress frame ordering

### DIFF
--- a/.dualpad-builder/progress.md
+++ b/.dualpad-builder/progress.md
@@ -1,5 +1,28 @@
 # DualPad Builder Progress
 
+## 2026-06-06 01:13:53 CST
+
+- `DP5-RC20` U1 ingress/frame contract hardening / 第二切片：
+  - 已创建分支 `codex/dp5-rc20-u1-ingress-frame-contract`。
+  - 本切片只处理 `FrameAssembler` strict seq / stable-window monotonic time invariant，以及 `IngressHub` typed overflow compaction；不处理 hook install failure、Axis2D、chord timestamp 或 primary path exclusivity。
+  - 已新增 `docs/superpowers/plans/2026-06-06-dp5-rc20-u1-ingress-frame-contract.md`。
+  - `IngressHub` overflow 现在生成带 `QueueOverflowPayload` 的单个 marker，保留最新 `ManifestEpochChanged`、`UiSnapshot`、`DeviceFamilyChanged`、`SourceEvidence`，并丢弃 volatile pad input backlog。
+  - `FrameAssembler` 现在按 drain 到达顺序消费，不再用排序修复乱序输入；seq gap / regression 与 stable window 内 monotonic time regression 会 fail-closed 到 `SequenceGap` transition。
+  - `QueueOverflow` payload 会先产出 `QueueOverflow` transition，再重建一份不含 `controlSamples` / `pulseLedger` / `legacySnapshot` 的 degraded baseline stable frame。
+- TDD / focused 验证结果：
+  - RED：`xmake build -y DualPadIngressTests` 首轮因 `IngressEvent::overflow` 不存在按预期编译失败。
+  - RED：补齐 payload 后，`xmake run -y DualPadIngressTests` 因旧 assembler 会把 out-of-order seq 排序回正常顺序按预期失败。
+  - GREEN：`xmake build -y DualPadIngressTests && xmake run -y DualPadIngressTests`：exit 0。
+  - `xmake build -y DualPadPropertyTests && xmake run -y DualPadPropertyTests`：exit 0。
+  - `xmake build -y DualPadReplayTests && xmake run -y DualPadReplayTests`：exit 0。
+- 完整验证结果：
+  - `powershell -ExecutionPolicy Bypass -File scripts/ci/run_phase8_ci.ps1`：exit 0；完整 build/run `DualPad`、6 个 canonical runtime targets、`DualPadPresentationProjectionTests`、`DualPadDocGen`，并通过 generated docs 与 reviewed-doc consistency 检查。
+  - `python scripts/dev/dualpad_trace_diff.py --batch tests/replay/golden/phase0 --actual-root build/replay --report-root build/replay-diff`：exit 0；10 个 phase0 replay 场景均为 `no diff`。
+  - `python -m json.tool .dualpad-builder/feature_list.json > $null`：exit 0。
+  - `python -m json.tool .dualpad-builder/sprint_plan.json > $null`：exit 0。
+  - `python3 scripts/dev/setup_graphify_local.py rebuild --reason manual-closeout`：exit 0，输出 `Rebuilt: 1554 nodes, 3188 edges, 144 communities`。
+  - `git diff --check`：exit 0；仅输出 CRLF 工作区提示，无 whitespace error。
+
 ## 2026-06-06 00:49:41 CST
 
 - `DP5-RC20` U1 PR #15 远端 Phase8 CI 修复：

--- a/docs/superpowers/plans/2026-06-06-dp5-rc20-u1-ingress-frame-contract.md
+++ b/docs/superpowers/plans/2026-06-06-dp5-rc20-u1-ingress-frame-contract.md
@@ -1,0 +1,130 @@
+# DP5-RC20 U1 Ingress Frame Contract 实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:test-driven-development 逐行为实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
+
+**目标：** 收紧 `FrameAssembler` 的 seq/time 合同，并让 `IngressHub` overflow 使用 typed compaction 保留最新边界事实、丢弃 volatile input。
+
+**架构：** `IngressHub` 在 overflow 时不再只发布裸 `QueueOverflow` marker，而是把最新 `ManifestEpochChanged`、`UiSnapshot`、`DeviceFamilyChanged`、`SourceEvidence` 事实打包进 `QueueOverflowPayload`。`FrameAssembler` 按到达顺序消费事件，不再排序；遇到 seq gap/regression 或 monotonic time regression 时发 transition 并 fail closed；遇到 typed overflow 时先发 `QueueOverflow` transition，再发布不含 control samples / pulse ledger / legacy snapshot 的 baseline stable frame。
+
+**技术栈：** C++17、xmake、现有 `DualPadIngressTests` / `DualPadPropertyTests` / Phase8 CI。
+
+---
+
+## 文件职责
+
+- 修改 `src/input_v2/ingress/IngressMarkers.h`：新增 `QueueOverflowPayload`，挂到 `IngressEvent`。
+- 修改 `src/input_v2/ingress/IngressHub.h/.cpp`：在 overflow 时扫描当前 backlog 与 incoming events，保留 latest typed boundary facts，生成单个 overflow event。
+- 修改 `src/input_v2/ingress/FrameAssembler.h/.cpp`：移除 Assemble 内排序；新增 seq/time watermark；处理 overflow payload 生成 transition 后 baseline stable frame。
+- 修改 `tests/input_v2/IngressTests.cpp`：新增红灯测试覆盖 overflow typed compaction、out-of-order seq 不被排序修正、monotonic time regression fail-closed。
+- 修改 `tests/input_v2/PropertyTests.cpp`：扩展 assembled frame invariant，确认 stable frame seq/time range 单调，transition 不 dispatch。
+- 修改 `.dualpad-builder/progress.md`：记录切片范围与验证结果。
+
+---
+
+### 任务 1：Typed Overflow Compaction 红灯
+
+- [ ] **步骤 1：在 `tests/input_v2/IngressTests.cpp` 添加测试**
+
+新增 `TestHubOverflowCompactsBoundaryFactsAndDropsVolatileInput()`：
+
+```cpp
+ingress::IngressHub hub{ 4 };
+Require(hub.PushEvent(Manifest(9)), "manifest marker must enqueue");
+Require(hub.PushEvent(Ui(21, 22)), "ui snapshot must enqueue");
+Require(hub.PushEvent(DeviceMarker(presentation::DeviceFamily::Gamepad, 7)), "device marker must enqueue");
+Require(hub.PushEvent(PadSample(99, true, true, false)), "volatile pad sample must enqueue");
+Require(!hub.PushEvent(SourceEvidence(7)), "source evidence should trigger overflow");
+
+const auto drained = hub.Drain();
+Require(drained.size() == 1, "overflow compaction emits one marker");
+Require(drained[0].kind == ingress::IngressKind::QueueOverflow, "marker kind required");
+Require(drained[0].overflow.hasManifest, "manifest retained");
+Require(drained[0].overflow.hasUi, "ui retained");
+Require(drained[0].overflow.hasDeviceFamily, "device retained");
+Require(drained[0].overflow.hasSourceEvidence, "source evidence retained");
+Require(drained[0].overflow.manifest.manifestEpoch == 9, "manifest epoch retained");
+```
+
+- [ ] **步骤 2：运行红灯**
+
+运行：`xmake build -y DualPadIngressTests && xmake run -y DualPadIngressTests`
+
+预期：编译失败，原因是 `IngressEvent` 还没有 `overflow` payload。
+
+- [ ] **步骤 3：最小实现**
+
+在 `IngressMarkers.h` 新增 payload；在 `IngressHub.cpp` 的 overflow 路径扫描 backlog + incoming events，写入 payload 后清空队列并 push 单个 marker。
+
+- [ ] **步骤 4：运行绿灯**
+
+运行同上，预期 `DualPadIngressTests passed`。
+
+### 任务 2：FrameAssembler Strict Seq / Time 红灯
+
+- [ ] **步骤 1：添加测试**
+
+新增 `TestFrameAssemblerDoesNotSortOutOfOrderEvents()`：
+
+```cpp
+auto events = AssignSeq({ Manifest(1), PadSample(1, true, true, false), PadSample(1, false, false, true) });
+std::swap(events[1], events[2]);
+ingress::FrameAssembler assembler;
+const auto frames = assembler.Assemble(events);
+Require(FindTransition(frames, ingress::TransitionReason::SequenceGap) != nullptr, "out-of-order seq must fail closed");
+```
+
+新增 `TestFrameAssemblerRejectsMonotonicTimeRegression()`：构造 seq 递增但 `monotonicUs` 倒退的 pad event，断言出现 `SequenceGap` transition 且倒退事件不进入最后 stable 的 `pulseLedger`。
+
+- [ ] **步骤 2：运行红灯**
+
+运行：`xmake build -y DualPadIngressTests && xmake run -y DualPadIngressTests`
+
+预期：当前 assembler 会排序或接受时间倒退，测试失败。
+
+- [ ] **步骤 3：最小实现**
+
+`FrameAssembler::Assemble()` 去掉排序，按输入顺序消费；新增 `_lastConsumedSeq` / `_lastMonotonicUs` watermark。seq gap 后发 `SequenceGap` transition 并继续消费当前新事件；seq regression 或 time regression 发 `SequenceGap` transition 并丢弃当前 volatile event。
+
+- [ ] **步骤 4：运行绿灯**
+
+运行同上，预期 `DualPadIngressTests passed`。
+
+### 任务 3：Overflow Payload 到 Baseline Stable
+
+- [ ] **步骤 1：添加测试**
+
+新增 `TestFrameAssemblerOverflowPayloadBuildsBoundaryBaseline()`：把任务 1 drain 出来的 overflow event 交给 assembler，断言第一帧是 `QueueOverflow` transition，最后一帧是 stable，`boundaryKey` 使用 payload 中 manifest/ui/device/source facts，且 `controlSamples` 与 `pulseLedger` 为空。
+
+- [ ] **步骤 2：运行红灯**
+
+运行：`xmake build -y DualPadIngressTests && xmake run -y DualPadIngressTests`
+
+预期：只有 transition，没有 payload baseline stable。
+
+- [ ] **步骤 3：最小实现**
+
+在 `FrameAssembler` 中新增 `ApplyOverflowCompaction()`：`EmitTransition(... QueueOverflow ...)` 后直接根据 payload 更新 `_currentKey` 与 `_latestFacts`，再发布一份无 volatile input 的 stable frame。
+
+- [ ] **步骤 4：运行绿灯**
+
+运行同上，预期 `DualPadIngressTests passed`。
+
+### 任务 4：Property / Closeout
+
+- [ ] **步骤 1：扩展 `PropertyTests.cpp`**
+
+断言 transition frame 不 dispatch；stable frame `firstSeq <= lastSeq`，且有非零时间时 `facts.monotonicUs` 不小于上一份 stable 的时间。
+
+- [ ] **步骤 2：运行 focused 验证**
+
+运行：
+
+```powershell
+xmake build -y DualPadIngressTests; xmake run -y DualPadIngressTests
+xmake build -y DualPadPropertyTests; xmake run -y DualPadPropertyTests
+xmake build -y DualPadReplayTests; xmake run -y DualPadReplayTests
+```
+
+- [ ] **步骤 3：完整验证与记录**
+
+运行 Phase8、replay diff、builder JSON lint、graphify rebuild、`git diff --check` / `git diff --cached --check`，并把结果写入 `.dualpad-builder/progress.md`。

--- a/src/input_v2/ingress/FrameAssembler.cpp
+++ b/src/input_v2/ingress/FrameAssembler.cpp
@@ -42,20 +42,18 @@ namespace dualpad::input_v2::ingress
         _currentKey = IngressBoundaryKey{};
         _latestFacts = FactFrame{};
         _window = Window{};
+        _lastConsumedSeq = 0;
+        _lastMonotonicUs = 0;
     }
 
     std::vector<AssembledFactFrame> FrameAssembler::Assemble(const std::vector<IngressEvent>& events)
     {
-        std::vector<IngressEvent> sorted = events;
-        std::sort(
-            sorted.begin(),
-            sorted.end(),
-            [](const IngressEvent& lhs, const IngressEvent& rhs) {
-                return lhs.seq < rhs.seq;
-            });
-
         std::vector<AssembledFactFrame> frames;
-        for (const auto& event : sorted) {
+        for (const auto& event : events) {
+            if (HandleOrderingViolation(frames, event)) {
+                continue;
+            }
+
             if (IsHealthMarker(event.kind)) {
                 FlushWindow(frames);
                 auto reason = TransitionReason::ExplicitReset;
@@ -65,6 +63,9 @@ namespace dualpad::input_v2::ingress
                     reason = TransitionReason::QueueOverflow;
                 }
                 EmitTransition(frames, _currentKey, _currentKey, reason);
+                if (event.kind == IngressKind::QueueOverflow) {
+                    ApplyOverflowCompaction(frames, event);
+                }
                 continue;
             }
 
@@ -131,6 +132,43 @@ namespace dualpad::input_v2::ingress
         _window.facts.monotonicUs = event.monotonicUs;
     }
 
+    bool FrameAssembler::HandleOrderingViolation(std::vector<AssembledFactFrame>& frames, const IngressEvent& event)
+    {
+        if (event.seq != 0) {
+            if (_lastConsumedSeq != 0) {
+                if (event.seq <= _lastConsumedSeq) {
+                    FlushWindow(frames);
+                    FactHealth health{};
+                    health.sequenceGap = true;
+                    EmitTransition(frames, _currentKey, _currentKey, TransitionReason::SequenceGap, health);
+                    return true;
+                }
+                if (event.kind != IngressKind::SequenceGap && event.seq > _lastConsumedSeq + 1) {
+                    FlushWindow(frames);
+                    FactHealth health{};
+                    health.sequenceGap = true;
+                    EmitTransition(frames, _currentKey, _currentKey, TransitionReason::SequenceGap, health);
+                }
+            }
+            _lastConsumedSeq = event.seq;
+        }
+
+        if (event.monotonicUs != 0) {
+            if (_window.open &&
+                _window.lastMonotonicUs != 0 &&
+                event.monotonicUs < _window.lastMonotonicUs) {
+                FlushWindow(frames);
+                FactHealth health{};
+                health.sequenceGap = true;
+                EmitTransition(frames, _currentKey, _currentKey, TransitionReason::SequenceGap, health);
+                return true;
+            }
+            _lastMonotonicUs = event.monotonicUs;
+        }
+
+        return false;
+    }
+
     void FrameAssembler::ApplyEventToWindow(const IngressEvent& event)
     {
         if (!_window.open) {
@@ -166,6 +204,63 @@ namespace dualpad::input_v2::ingress
         }
 
         _latestFacts = _window.facts;
+    }
+
+    void FrameAssembler::ApplyOverflowCompaction(std::vector<AssembledFactFrame>& frames, const IngressEvent& event)
+    {
+        const auto& payload = event.overflow;
+        if (!payload.hasManifest &&
+            !payload.hasUi &&
+            !payload.hasDeviceFamily &&
+            !payload.hasSourceEvidence) {
+            return;
+        }
+
+        auto nextKey = _currentKey;
+        if (payload.hasManifest) {
+            nextKey.manifestEpoch = payload.manifest.manifestEpoch;
+        }
+        if (payload.hasUi) {
+            nextKey.contextRevision = payload.ui.contextRevision;
+            nextKey.menuStackRevision = payload.ui.menuStackRevision;
+        }
+        if (payload.hasDeviceFamily) {
+            nextKey.deviceFamilyRevision = payload.deviceFamily.deviceFamilyRevision;
+        }
+
+        FactFrame facts = _latestFacts;
+        facts.controlSamples.clear();
+        facts.pulseLedger.clear();
+        facts.legacySnapshot.reset();
+        facts.health = FactHealth{};
+        facts.health.queueOverflow = true;
+        facts.monotonicUs = event.monotonicUs;
+        if (payload.hasSourceEvidence) {
+            facts.sourceEvidence = payload.sourceEvidence;
+            if (payload.hasDeviceFamily &&
+                payload.sourceEvidence.deviceFamilyEvidence.deviceFamilyRevision !=
+                    payload.deviceFamily.deviceFamilyRevision) {
+                facts.health.pendingBoundaryMarkerPair = true;
+                facts.health.boundaryMarkerMismatch = true;
+            }
+        } else if (payload.hasDeviceFamily) {
+            facts.health.pendingBoundaryMarkerPair = true;
+        }
+        ApplyFactsFromBoundaryKey(facts, nextKey);
+
+        frames.push_back(AssembledFactFrame{
+            .kind = AssembledFrameKind::Stable,
+            .firstSeq = event.seq,
+            .lastSeq = event.seq,
+            .boundaryKey = nextKey,
+            .facts = facts
+        });
+
+        _currentKey = nextKey;
+        _latestFacts = facts;
+        _latestFacts.health = FactHealth{};
+        _window = Window{};
+        _pendingDeviceMarker.reset();
     }
 
     void FrameAssembler::FlushWindow(std::vector<AssembledFactFrame>& frames)

--- a/src/input_v2/ingress/FrameAssembler.h
+++ b/src/input_v2/ingress/FrameAssembler.h
@@ -84,8 +84,11 @@ namespace dualpad::input_v2::ingress
         IngressBoundaryKey _currentKey{};
         FactFrame _latestFacts{};
         Window _window{};
+        std::uint64_t _lastConsumedSeq{ 0 };
+        std::uint64_t _lastMonotonicUs{ 0 };
 
         void ApplyEventToWindow(const IngressEvent& event);
+        void ApplyOverflowCompaction(std::vector<AssembledFactFrame>& frames, const IngressEvent& event);
         void ApplyFactsFromBoundaryKey(FactFrame& facts, const IngressBoundaryKey& key) const;
         void FlushWindow(std::vector<AssembledFactFrame>& frames);
         void EmitTransition(
@@ -96,6 +99,7 @@ namespace dualpad::input_v2::ingress
             FactHealth health = {});
         void StartWindow(const IngressEvent& event);
         void HandleBoundaryChange(std::vector<AssembledFactFrame>& frames, const IngressEvent& event, IngressBoundaryKey nextKey, TransitionReason reason);
+        bool HandleOrderingViolation(std::vector<AssembledFactFrame>& frames, const IngressEvent& event);
         void HandleSourceEvidence(std::vector<AssembledFactFrame>& frames, const IngressEvent& event);
     };
 

--- a/src/input_v2/ingress/IngressHub.cpp
+++ b/src/input_v2/ingress/IngressHub.cpp
@@ -9,6 +9,51 @@
 
 namespace dualpad::input_v2::ingress
 {
+    namespace
+    {
+        void CaptureOverflowFact(QueueOverflowPayload& payload, const IngressEvent& event)
+        {
+            switch (event.kind) {
+            case IngressKind::ManifestEpochChanged:
+                payload.hasManifest = true;
+                payload.manifest = event.manifest;
+                break;
+            case IngressKind::UiSnapshot:
+                payload.hasUi = true;
+                payload.ui = event.ui;
+                break;
+            case IngressKind::DeviceFamilyChanged:
+                payload.hasDeviceFamily = true;
+                payload.deviceFamily = event.deviceFamily;
+                break;
+            case IngressKind::SourceEvidence:
+                payload.hasSourceEvidence = true;
+                payload.sourceEvidence = event.sourceEvidence;
+                break;
+            case IngressKind::QueueOverflow:
+                if (event.overflow.hasManifest) {
+                    payload.hasManifest = true;
+                    payload.manifest = event.overflow.manifest;
+                }
+                if (event.overflow.hasUi) {
+                    payload.hasUi = true;
+                    payload.ui = event.overflow.ui;
+                }
+                if (event.overflow.hasDeviceFamily) {
+                    payload.hasDeviceFamily = true;
+                    payload.deviceFamily = event.overflow.deviceFamily;
+                }
+                if (event.overflow.hasSourceEvidence) {
+                    payload.hasSourceEvidence = true;
+                    payload.sourceEvidence = event.overflow.sourceEvidence;
+                }
+                break;
+            default:
+                break;
+            }
+        }
+    }
+
     IngressHub::IngressHub(std::size_t capacity) :
         _capacity(capacity)
     {}
@@ -39,7 +84,7 @@ namespace dualpad::input_v2::ingress
             event.monotonicUs = NowMonotonicUs();
         }
         if (_queue.size() >= _capacity) {
-            ReplaceBacklogWithOverflowLocked(event.seq, event.monotonicUs);
+            ReplaceBacklogWithOverflowLocked(event.seq, event.monotonicUs, { event });
             return false;
         }
         _queue.push_back(std::move(event));
@@ -49,18 +94,27 @@ namespace dualpad::input_v2::ingress
     bool IngressHub::PushLocked(IngressEvent event)
     {
         if (_queue.size() >= _capacity) {
-            ReplaceBacklogWithOverflowLocked(event.seq, event.monotonicUs);
+            ReplaceBacklogWithOverflowLocked(event.seq, event.monotonicUs, { event });
             return false;
         }
         _queue.push_back(std::move(event));
         return true;
     }
 
-    void IngressHub::ReplaceBacklogWithOverflowLocked(std::uint64_t seq, std::uint64_t monotonicUs)
+    void IngressHub::ReplaceBacklogWithOverflowLocked(
+        std::uint64_t seq,
+        std::uint64_t monotonicUs,
+        const std::vector<IngressEvent>& incomingEvents)
     {
         IngressEvent overflow = MakeQueueOverflowEvent();
         overflow.seq = seq;
         overflow.monotonicUs = monotonicUs != 0 ? monotonicUs : NowMonotonicUs();
+        for (const auto& event : _queue) {
+            CaptureOverflowFact(overflow.overflow, event);
+        }
+        for (const auto& event : incomingEvents) {
+            CaptureOverflowFact(overflow.overflow, event);
+        }
         _queue.clear();
         _queue.push_back(overflow);
     }
@@ -74,7 +128,7 @@ namespace dualpad::input_v2::ingress
         if (converted.size() > available) {
             const auto overflowSeq = NextSeqLocked();
             const auto overflowTime = snapshot.sourceTimestampUs != 0 ? snapshot.sourceTimestampUs : NowMonotonicUs();
-            ReplaceBacklogWithOverflowLocked(overflowSeq, overflowTime);
+            ReplaceBacklogWithOverflowLocked(overflowSeq, overflowTime, converted);
             // QueueOverflow represents a dropped legacy input range through this snapshot.
             // Advance the watermark so the next contiguous accepted snapshot does not
             // report a second SequenceGap for the same discarded range.

--- a/src/input_v2/ingress/IngressHub.h
+++ b/src/input_v2/ingress/IngressHub.h
@@ -31,7 +31,10 @@ namespace dualpad::input_v2::ingress
         std::uint64_t NextSeqLocked();
         std::uint64_t NowMonotonicUs() const;
         bool PushLocked(IngressEvent event);
-        void ReplaceBacklogWithOverflowLocked(std::uint64_t seq, std::uint64_t monotonicUs);
+        void ReplaceBacklogWithOverflowLocked(
+            std::uint64_t seq,
+            std::uint64_t monotonicUs,
+            const std::vector<IngressEvent>& incomingEvents = {});
 
         std::size_t _capacity{ 256 };
         std::uint64_t _nextSeq{ 1 };

--- a/src/input_v2/ingress/IngressMarkers.h
+++ b/src/input_v2/ingress/IngressMarkers.h
@@ -67,6 +67,18 @@ namespace dualpad::input_v2::ingress
         std::uint32_t deviceFamilyRevision{ 0 };
     };
 
+    struct QueueOverflowPayload
+    {
+        bool hasManifest{ false };
+        ManifestEpochChangedPayload manifest;
+        bool hasUi{ false };
+        UiSnapshotPayload ui;
+        bool hasDeviceFamily{ false };
+        DeviceFamilyChangedPayload deviceFamily;
+        bool hasSourceEvidence{ false };
+        presentation::SourceEvidenceSnapshot sourceEvidence;
+    };
+
     struct IngressEvent
     {
         std::uint64_t seq{ 0 };
@@ -79,6 +91,7 @@ namespace dualpad::input_v2::ingress
         presentation::SourceEvidenceSnapshot sourceEvidence;
         ManifestEpochChangedPayload manifest;
         DeviceFamilyChangedPayload deviceFamily;
+        QueueOverflowPayload overflow;
     };
 
     IngressEvent MakeSequenceGapEvent();

--- a/tests/input_v2/IngressTests.cpp
+++ b/tests/input_v2/IngressTests.cpp
@@ -128,6 +128,17 @@ namespace
         return frames.back();
     }
 
+    const ingress::AssembledFactFrame& LastStableFrame(const std::vector<ingress::AssembledFactFrame>& frames)
+    {
+        for (auto it = frames.rbegin(); it != frames.rend(); ++it) {
+            if (it->kind == ingress::AssembledFrameKind::Stable) {
+                return *it;
+            }
+        }
+        Require(false, "frames must contain a stable frame");
+        return frames.back();
+    }
+
     const actions::ControlSample* FindPulse(
         const ingress::FactFrame& facts,
         std::uint32_t code,
@@ -156,6 +167,33 @@ namespace
         Require(drained.size() == 1, "overflow must replace backlog with one marker");
         Require(drained[0].kind == ingress::IngressKind::QueueOverflow, "overflow marker must be formal event");
         Require(drained[0].seq == 3, "hub must assign monotonic seq to overflow marker");
+    }
+
+    void TestHubOverflowCompactsBoundaryFactsAndDropsVolatileInput()
+    {
+        ingress::IngressHub hub{ 4 };
+        Require(hub.PushEvent(Manifest(9)), "manifest marker must enqueue");
+        Require(hub.PushEvent(Ui(21, 22)), "ui snapshot must enqueue");
+        Require(
+            hub.PushEvent(DeviceMarker(presentation::DeviceFamily::Gamepad, 7)),
+            "device marker must enqueue");
+        Require(hub.PushEvent(PadSample(99, true, true, false)), "volatile pad sample must enqueue");
+        Require(!hub.PushEvent(SourceEvidence(7)), "source evidence should trigger overflow");
+
+        const auto drained = hub.Drain();
+        Require(drained.size() == 1, "overflow compaction emits one marker");
+        Require(drained[0].kind == ingress::IngressKind::QueueOverflow, "overflow marker kind required");
+        Require(drained[0].overflow.hasManifest, "overflow compaction must retain latest manifest");
+        Require(drained[0].overflow.hasUi, "overflow compaction must retain latest ui snapshot");
+        Require(drained[0].overflow.hasDeviceFamily, "overflow compaction must retain latest device marker");
+        Require(drained[0].overflow.hasSourceEvidence, "overflow compaction must retain latest source evidence");
+        Require(drained[0].overflow.manifest.manifestEpoch == 9, "manifest epoch must be retained");
+        Require(drained[0].overflow.ui.contextRevision == 21, "ui context revision must be retained");
+        Require(drained[0].overflow.ui.menuStackRevision == 22, "ui menu stack revision must be retained");
+        Require(drained[0].overflow.deviceFamily.deviceFamilyRevision == 7, "device revision must be retained");
+        Require(
+            drained[0].overflow.sourceEvidence.deviceFamilyEvidence.deviceFamilyRevision == 7,
+            "source evidence revision must be retained");
     }
 
     void TestLegacySnapshotAdapterProducesControlSamplesAndPulseLedger()
@@ -556,6 +594,70 @@ namespace
         Require(ToGameplayRecoveryInput(*overflow).hardResetRequested, "queue overflow maps to hard recovery input");
     }
 
+    void TestFrameAssemblerDoesNotSortOutOfOrderEvents()
+    {
+        auto events = AssignSeq({
+            Manifest(1),
+            PadSample(1, true, true, false),
+            PadSample(1, false, false, true)
+        });
+        std::swap(events[1], events[2]);
+
+        ingress::FrameAssembler assembler;
+        const auto frames = assembler.Assemble(events);
+        Require(
+            FindTransition(frames, ingress::TransitionReason::SequenceGap) != nullptr,
+            "out-of-order seq must fail closed instead of being sorted back into order");
+    }
+
+    void TestFrameAssemblerRejectsMonotonicTimeRegression()
+    {
+        auto events = AssignSeq({
+            Manifest(1),
+            PadSample(1, true, true, false),
+            PadSample(1, false, false, true)
+        });
+        events[2].monotonicUs = events[1].monotonicUs - 1;
+
+        ingress::FrameAssembler assembler;
+        const auto frames = assembler.Assemble(events);
+        Require(
+            FindTransition(frames, ingress::TransitionReason::SequenceGap) != nullptr,
+            "monotonic time regression must fail closed through a transition");
+
+        const auto& stable = LastStableFrame(frames);
+        Require(
+            FindPulse(stable.facts, 1, false, true) == nullptr,
+            "time-regressed volatile release must not enter stable pulse ledger");
+    }
+
+    void TestFrameAssemblerOverflowPayloadBuildsBoundaryBaseline()
+    {
+        ingress::IngressHub hub{ 4 };
+        Require(hub.PushEvent(Manifest(9)), "manifest marker must enqueue");
+        Require(hub.PushEvent(Ui(21, 22)), "ui snapshot must enqueue");
+        Require(
+            hub.PushEvent(DeviceMarker(presentation::DeviceFamily::Gamepad, 7)),
+            "device marker must enqueue");
+        Require(hub.PushEvent(PadSample(99, true, true, false)), "volatile pad sample must enqueue");
+        Require(!hub.PushEvent(SourceEvidence(7)), "source evidence should trigger overflow");
+
+        ingress::FrameAssembler assembler;
+        const auto frames = assembler.Assemble(hub.Drain());
+        Require(frames.size() == 2, "overflow payload must produce transition plus baseline stable");
+        Require(frames[0].kind == ingress::AssembledFrameKind::Transition, "overflow transition must come first");
+        Require(frames[0].transition.reason == ingress::TransitionReason::QueueOverflow, "transition reason must be overflow");
+        const auto& stable = frames[1];
+        Require(stable.kind == ingress::AssembledFrameKind::Stable, "overflow payload must rebuild stable baseline");
+        Require(
+            stable.boundaryKey == (ingress::IngressBoundaryKey{ 9, 21, 22, 7 }),
+            "overflow baseline must retain latest boundary facts");
+        Require(stable.facts.controlSamples.empty(), "overflow baseline must drop volatile control samples");
+        Require(stable.facts.pulseLedger.empty(), "overflow baseline must drop volatile pulse ledger");
+        Require(!stable.facts.legacySnapshot, "overflow baseline must drop legacy snapshot payload");
+        Require(stable.facts.health.queueOverflow, "overflow baseline must remain degraded for the current frame");
+    }
+
     void TestDeviceMarkerMismatchFailsClosed()
     {
         ingress::FrameAssembler assembler;
@@ -609,6 +711,7 @@ namespace
 int main()
 {
     TestHubAssignsSeqAndEmitsOverflowMarker();
+    TestHubOverflowCompactsBoundaryFactsAndDropsVolatileInput();
     TestLegacySnapshotAdapterProducesControlSamplesAndPulseLedger();
     TestLegacySnapshotBatchOverflowRejectsPartialEvents();
     TestRejectedLegacySnapshotAdvancesWatermarkAsDroppedRange();
@@ -623,6 +726,9 @@ int main()
     TestStableMergeKeepsPulseLedger();
     TestBoundaryChangeFlushesStableThenTransition();
     TestRecoveryMarkersMapFailClosed();
+    TestFrameAssemblerDoesNotSortOutOfOrderEvents();
+    TestFrameAssemblerRejectsMonotonicTimeRegression();
+    TestFrameAssemblerOverflowPayloadBuildsBoundaryBaseline();
     TestDeviceMarkerMismatchFailsClosed();
     TestBuildKernelFrameDoesNotAcceptTransition();
     TestBuildKernelFrameUsesIngressMonotonicTimestamp();

--- a/tests/input_v2/PropertyTests.cpp
+++ b/tests/input_v2/PropertyTests.cpp
@@ -37,8 +37,19 @@ int main()
     FrameAssembler assembler;
     const auto frames = assembler.Assemble(drained);
     Require(!frames.empty(), "property assembler should publish at least one frame");
+    std::uint64_t lastStableTime = 0;
     for (const auto& frame : frames) {
         Require(frame.firstSeq <= frame.lastSeq, "assembled frame sequence range must be ordered");
+        if (frame.kind == AssembledFrameKind::Transition) {
+            Require(!ShouldDispatchToInteractionEngine(frame), "transition frames must not dispatch");
+            continue;
+        }
+        if (frame.facts.monotonicUs != 0 && lastStableTime != 0) {
+            Require(frame.facts.monotonicUs >= lastStableTime, "stable frame monotonic time must not regress");
+        }
+        if (frame.facts.monotonicUs != 0) {
+            lastStableTime = frame.facts.monotonicUs;
+        }
     }
 
     return 0;


### PR DESCRIPTION
## Summary

Implements the second DP5-RC20 U1 runtime determinism slice.

- Adds typed `QueueOverflowPayload` so ingress overflow retains latest manifest, UI, device-family, and source-evidence facts while dropping volatile pad input backlog.
- Makes `FrameAssembler` consume drain order directly instead of sorting by sequence.
- Converts seq gap/regression and stable-window monotonic time regression into fail-closed `SequenceGap` transition behavior.
- Rebuilds an overflow baseline stable frame after the `QueueOverflow` transition without `controlSamples`, `pulseLedger`, or legacy snapshot payload.
- Extends ingress/property tests around ordering, overflow compaction, transition dispatch, and stable frame time invariants.

Refs #8.

## Scope Boundary

This PR leaves #8 open for remaining U1 work: hook install runtime contract, Axis2D value semantics, chord timestamp semantics, primary path exclusivity, and any broader property/fuzz expansion after these ingress invariants are reviewed.

## Verification

- `xmake build -y DualPadIngressTests && xmake run -y DualPadIngressTests`
- `xmake build -y DualPadPropertyTests && xmake run -y DualPadPropertyTests`
- `xmake build -y DualPadReplayTests && xmake run -y DualPadReplayTests`
- `powershell -ExecutionPolicy Bypass -File scripts/ci/run_phase8_ci.ps1`
- `python scripts/dev/dualpad_trace_diff.py --batch tests/replay/golden/phase0 --actual-root build/replay --report-root build/replay-diff`
- `python -m json.tool .dualpad-builder/feature_list.json > $null`
- `python -m json.tool .dualpad-builder/sprint_plan.json > $null`
- `python3 scripts/dev/setup_graphify_local.py rebuild --reason manual-closeout`
- `git diff --check`
- `git diff --cached --check`
