### PR TITLE
Complete DP5-RC20 U5 RC readiness closeout

### DIFF
--- a/.dualpad-builder/feature_list.json
+++ b/.dualpad-builder/feature_list.json
@@ -6,7 +6,7 @@
     "README.md",
     "src/ARCHITECTURE.md"
   ],
-  "updated_at": "2026-06-07T23:27:42+08:00",
+  "updated_at": "2026-06-08T00:18:00+08:00",
   "features": [
     {
       "id": "WF0",
@@ -344,9 +344,10 @@
         "U1.9 Axis2D / chord timestamp / primary path contracts 已进入 input_v2 内部语义模型与 focused/property tests，不改变 prompt/glyph public shape",
         "U2 legacy boundary collapse 已证明 PadEventSnapshotProcessor 只作为 compat/replay ingress bridge，legacySnapshot 不回流 core kernel，旧 #2/#3/#4/#6 已由删除或迁移证明关闭，旧 #5 重新归类为 U5 / non-authority cleanup",
         "U3 product integration and release readiness 已补 release readiness static gate、stale LKG fail-closed test、release notes 与 release artifact manifest generator；最终 manifest 作为 build/release 生成物对齐 source commit / generated docs / config manifest",
-        "U4 config / prompt / menu / glyph contract closure 冻结 zero-direct context 分类、unknown_menu_policy=passthrough / ignored menu 行为、FavoritesMenu non-restore workspace 边界、prompt fail-closed 矩阵与 glyph/icon contract diagnostics",
+        "U4 config / prompt / menu / glyph contract closure 已通过 PR #20 合入 main，冻结 zero-direct context 分类、unknown_menu_policy=passthrough / ignored menu 行为、FavoritesMenu non-restore workspace 边界、prompt fail-closed 矩阵与 glyph/icon contract diagnostics",
+        "U5 verification / observability / governance closeout 已新增 RC readiness outer gate，聚合 Phase8、replay diff、graphify、builder JSON、generated docs、legacy boundary、release readiness、U4 contract gate 与 artifact manifest，并记录 real-game QA matrix、performance budget 和 debug snapshot/log surface 覆盖",
         "任何 DP5-RC20 slice 都不得重开 input_v2 runtime mainline、canonical target 名称、replay root、旧 SWF 返回 shape、FavoritesMenu workspace 或 legacy glyph authority",
-        "后续 U1-U5 必须继续通过 Phase 8 canonical CI、builder JSON、graphify、replay diff 与 diff hygiene"
+        "DP5-RC20 U0-U5 closeout 必须通过 Phase 8 canonical CI、RC readiness outer gate、builder JSON、graphify、replay diff 与 diff hygiene"
       ]
     }
   ]

--- a/.dualpad-builder/progress.md
+++ b/.dualpad-builder/progress.md
@@ -2463,3 +2463,37 @@
   - U4 已冻结 config / prompt / menu / glyph 用户可见合同：zero-direct context 分类、`unknown_menu_policy=passthrough` / ignored menu 行为、`FavoritesMenu` non-restore workspace、prompt fail-closed 矩阵与 glyph/icon diagnostics。
   - 本轮未新增 runtime phase，未改变 `src/input_v2/` mainline，未改旧 SWF token API，未恢复 `FavoritesMenu` workspace、`BindingManager` 或 trigger reverse lookup authority。
   - `DP5` / `S-DP5` 整体仍保持 planned；U5 尚未完成。
+
+## 2026-06-08 00:18:00 CST
+
+- 已将 PR #20 合并到 `main`：
+  - PR #20 `Complete DP5-RC20 U4 config prompt menu glyph closure` 的远端 `phase8` check 已在 head `08e28c3bc050b347b8a382d08e1ba0c928ddd572` 上通过。
+  - PR #20 以 merge commit `356837d6b0c51c01671a4f7f273932347d435a91` 合入 `main`。
+  - 本轮 U5 工作分支基于该 merge commit 创建：`codex/dp5-rc20-u5-verification-observability-governance`。
+- `DP5-RC20` U5 Verification / observability / governance closeout 已开始推进：
+  - U5 只新增 RC readiness outer gate 与治理/验证文档；不新增 runtime phase，不改变 `src/input_v2/` mainline，不改 canonical target 名称、replay root、旧 SWF 返回 shape 或 `FavoritesMenu` workspace。
+  - `scripts/ci/run_rc_readiness.ps1` 作为 Phase8 外层 gate，先调用 `scripts/ci/run_phase8_ci.ps1`，再聚合 replay diff、builder JSON、reviewed/generated docs consistency、legacy boundary、release readiness、U4 contract gate、DInput8 proxy build、release artifact manifest、graphify rebuild 与 diff hygiene。
+  - `docs/releases/dp5_rc20_u5_rc_readiness_closeout_zh.md` 已记录 real-game QA matrix、performance budget、debug snapshot/log surface 覆盖和旧 #5 non-authority cleanup 结论。
+  - `.dualpad-builder/feature_list.json` 与 `.dualpad-builder/sprint_plan.json` 已同步 U5 gate 与 closeout 口径；`DP5` / `S-DP5` 继续保持 planned，表示 post-closeout hardening backlog，而不是新的 runtime phase。
+
+## 2026-06-08 00:22:30 CST
+
+- `DP5-RC20` U5 本地 close-out 验证完成：
+  - `python scripts/ci/check_rc_readiness_closeout.py`：exit 0，输出 `RC readiness closeout check passed`。
+  - `python scripts/ci/check_reviewed_docs_consistency.py`：exit 0，输出 `reviewed docs consistency check passed`。
+  - `python -m json.tool .dualpad-builder/feature_list.json NUL` 与 `python -m json.tool .dualpad-builder/sprint_plan.json NUL`：exit 0。
+  - `powershell -ExecutionPolicy Bypass -File scripts/ci/run_phase8_ci.ps1`：exit 0；构建/运行 `DualPad`、6 个 canonical runtime targets、`DualPadPresentationProjectionTests`、`DualPadDocGen`，并通过 reviewed docs consistency、legacy authority boundary、release readiness、U4 config/prompt/menu/glyph closure 与 generated docs clean-diff。DocGen manifest hash 保持 `60ab6dd5bcb07037`。
+  - `powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1`：exit 0；先运行 Phase8，再完成 `DualPadReplayHarness` build、phase0 dispatcher replay generation、10 个 replay scenarios `no diff`、builder JSON、reviewed docs consistency、legacy boundary、release readiness、U4 contract gate、U5 RC closeout static gate、`DualPadDInput8Proxy` build、release artifact manifest generation、graphify rebuild 与 `git diff --check`。
+  - `python3 scripts/dev/setup_graphify_local.py rebuild --reason manual-closeout` 由 RC gate 执行，输出 `Rebuilt: 1654 nodes, 3476 edges, 145 communities`。
+- 状态结论：
+  - U5 已建立 `scripts/ci/run_rc_readiness.ps1` 作为 Phase8 外层 RC readiness gate；Phase8 仍是 canonical base gate，不替代 canonical targets。
+  - Real-game QA matrix、performance budget、debug snapshot/log surface 覆盖与旧 #5 non-authority cleanup 结论已写入 `docs/releases/dp5_rc20_u5_rc_readiness_closeout_zh.md`。
+  - U5 本轮未新增 runtime phase，未改变 `src/input_v2/` mainline，未改 canonical target 名称、replay root、旧 SWF 返回 shape 或 `FavoritesMenu` workspace。
+
+## 2026-06-08 00:30:00 CST
+
+- U5 final commit 后 `powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1 -ExpectCleanManifest` 首次运行失败于 release artifact manifest 步骤：
+  - 失败前已通过 Phase8、phase0 replay generation / diff、builder JSON、reviewed docs consistency、legacy boundary、release readiness、U4 contract gate、U5 RC closeout static gate 与 `DualPadDInput8Proxy` build。
+  - 失败点：`scripts/dev/generate_release_artifact_manifest.py --require-build-artifacts --expect-clean` 报 `tracked working tree is dirty`。
+  - 根因：Phase8 / DocGen 后 `docs/generated/*.md` 出现 CRLF stat-only working tree 状态；`git diff --exit-code -- docs/generated` 无内容 diff，但原 manifest generator 使用 `git status --porcelain --untracked-files=no`，会把该行尾状态误判为 tracked dirty。
+  - 修复：`scripts/dev/generate_release_artifact_manifest.py` 的 dirty 判定改为 `git diff --quiet --` + `git diff --cached --quiet --`，只按 tracked content / index diff 判断 `trackedWorkingTreeDirty`。

--- a/.dualpad-builder/sprint_plan.json
+++ b/.dualpad-builder/sprint_plan.json
@@ -2,7 +2,7 @@
   "project": "DualPad Authoritative Baseline",
   "status": "active",
   "current_sprint": null,
-  "updated_at": "2026-06-07T23:27:42+08:00",
+  "updated_at": "2026-06-08T00:18:00+08:00",
   "sprints": [
     {
       "id": "S-WF0",
@@ -488,7 +488,7 @@
       "exit_criteria": [
         "只做 DP5-RC20 post-closeout governance / validation / reporting hardening，不重开 runtime mainline",
         "不改 canonical target 名称、replay root、旧 SWF 返回 shape或 input_v2 runtime 合同",
-        "U0 contract preflight 已完成；U1-U5 必须按 issue 顺序分 slice 推进并记录 progress start / verification / closeout"
+        "U0-U5 已按 issue 顺序分 slice 推进；DP5-RC20 closeout 记录必须保留 progress start / verification / closeout"
       ],
       "verification": [
         "U0: docs/authoritative-baseline/dp5_rc20_contract_zh.md 已新增并从 authoritative baseline / DOC index 接入",
@@ -496,8 +496,8 @@
         "U1.9: Axis2D / chord timestamp / primary path contracts 必须通过 DualPadInputV2Tests、DualPadGameplayProjectionTests、DualPadPropertyTests、Phase 8 CI、replay diff、reviewed/generated docs consistency、builder JSON、graphify rebuild 与 git diff --check",
         "U2: legacy boundary collapse 必须通过 DualPadIngressTests、scripts/ci/check_legacy_authority_boundary.py、Phase 8 CI、replay diff、reviewed/generated docs consistency、builder JSON、graphify rebuild 与 git diff --check",
         "U3: product integration and release readiness 必须通过 DualPadManifestCompilerTests、scripts/ci/check_release_readiness.py、Phase 8 CI、DualPadDInput8Proxy build、release artifact manifest generation、replay diff、builder JSON、reviewed/generated docs consistency、legacy authority boundary check、graphify rebuild 与 git diff --check",
-        "U4: config / prompt / menu / glyph contract closure 必须通过 DualPadPromptSnapshotTests、DualPadManifestCompilerTests、scripts/ci/check_config_prompt_menu_glyph_closure.py、Phase 8 CI、replay diff、reviewed/generated docs consistency、builder JSON、legacy authority boundary check、graphify rebuild 与 git diff --check",
-        "后续具体 hardening slice 默认至少包含 scripts/ci/run_phase8_ci.ps1、builder JSON 校验、graphify rebuild 和 git diff --check"
+        "U4: config / prompt / menu / glyph contract closure 已通过 DualPadPromptSnapshotTests、DualPadManifestCompilerTests、scripts/ci/check_config_prompt_menu_glyph_closure.py、Phase 8 CI、replay diff、reviewed/generated docs consistency、builder JSON、legacy authority boundary check、graphify rebuild 与 git diff --check",
+        "U5: verification / observability / governance closeout 必须通过 scripts/ci/run_phase8_ci.ps1、scripts/ci/run_rc_readiness.ps1、scripts/ci/check_rc_readiness_closeout.py、replay diff、builder JSON、reviewed/generated docs consistency、legacy boundary、release readiness、U4 contract gate、release artifact manifest generation、graphify rebuild 与 git diff --check"
       ]
     }
   ]

--- a/docs/DOC_INDEX_zh.md
+++ b/docs/DOC_INDEX_zh.md
@@ -51,6 +51,7 @@
 - [authoritative-baseline/dp5_rc20_contract_zh.md](authoritative-baseline/dp5_rc20_contract_zh.md)
 - [releases/dp5_rc20_u3_release_notes_zh.md](releases/dp5_rc20_u3_release_notes_zh.md)
 - [releases/dp5_rc20_u4_config_prompt_menu_glyph_contract_zh.md](releases/dp5_rc20_u4_config_prompt_menu_glyph_contract_zh.md)
+- [releases/dp5_rc20_u5_rc_readiness_closeout_zh.md](releases/dp5_rc20_u5_rc_readiness_closeout_zh.md)
 - [backend_routing_decisions.md](backend_routing_decisions.md)
 - [unified_action_lifecycle_model_zh.md](unified_action_lifecycle_model_zh.md)
 - [main_menu_glyph_current_status_zh.md](main_menu_glyph_current_status_zh.md)

--- a/docs/authoritative-baseline/dp5_rc20_contract_zh.md
+++ b/docs/authoritative-baseline/dp5_rc20_contract_zh.md
@@ -207,6 +207,16 @@ U4 内部 contract 字段进入 `PromptCandidate` / `PromptLegacyGlyphDescriptor
 - config / prompt / menu matrix ambiguity 影响用户可见行为。
 - 缺少 canonical runtime targets、replay、property / fuzz、generated docs、graphify 或 builder JSON 的 RC 验证记录。
 
+## U5 Verification / Observability / Governance Closeout
+
+U5 的结论记录在 `docs/releases/dp5_rc20_u5_rc_readiness_closeout_zh.md`。`Phase8 是 canonical base gate`：`scripts/ci/run_phase8_ci.ps1` 继续直接引用并运行同名 canonical targets，不被新的 wrapper target 替代。
+
+U5 新增 `RC readiness outer gate`：`scripts/ci/run_rc_readiness.ps1`。该 gate 先调用 Phase8，再聚合 replay diff、graphify、builder JSON、generated docs clean diff、legacy boundary、release readiness、U4 contract gate、release artifact manifest、DInput8 proxy build 与 diff hygiene。
+
+U5 同时冻结 `Real-game QA matrix` 与 `Performance budget`：手工 QA 覆盖启动、读档、死亡/重载、快速旅行、alt-tab、设备 hot-plug / disconnect / reconnect、常见菜单、FavoritesMenu non-restore 边界、高频输入、长按切菜单、chord reload、prompt/config reload 和 graph/context change；性能预算覆盖 stable runtime frame、prompt resolve、graph/config reload、ingress queue high-water、overflow count、degraded reason transition count 与 log volume。
+
+Debug snapshot/log surface 当前必须能覆盖 degraded reasons、prompt freeze、overflow compaction、hook failure、manifest/config/context generation。正式 reason 名称保持为 `GraphUnavailable`、`ManifestEpochSkew`、`ContextRevisionSkew`、`QueueOverflow`、`SequenceGap`、`BoundaryMismatch`、`PromptScopeFrozen` 与 `HookInstallFailed`；日志按 reason-transition 去重，避免 per-frame log storm。
+
 ## Non-Goals
 
 - 不新增 runtime phase。

--- a/docs/authoritative-baseline/work-packages/README.md
+++ b/docs/authoritative-baseline/work-packages/README.md
@@ -54,8 +54,8 @@
 - U1：runtime determinism hardening 已完成并经 PR #17 合入 `main`。
 - U2：legacy boundary collapse 已完成本地实现；legacy-named shim / adapter 边界由 focused ingress test 与 Phase8 static check 固化。
 - U3：product integration and release readiness 已通过 PR #19 合入 `main`；release readiness static gate、stale LKG fail-closed test、release notes 与 release artifact manifest generator 已接入。
-- U4：config / prompt / menu / glyph contract closure 正在推进；目标是冻结 zero-direct context 分类、unknown / ignored menu 行为、prompt fail-closed 矩阵和 glyph/icon contract。
-- U5：verification / observability / governance closeout。
+- U4：config / prompt / menu / glyph contract closure 已通过 PR #20 合入 `main`；zero-direct context 分类、unknown / ignored menu 行为、prompt fail-closed 矩阵和 glyph/icon contract 已冻结。
+- U5：verification / observability / governance closeout 已完成；RC readiness outer gate、real-game QA matrix、performance budget 与 debug snapshot/log surface 已收口。
 
 硬边界：
 
@@ -103,6 +103,7 @@
 - `python scripts/dev/dualpad_trace_diff.py --batch tests/replay/golden/phase0 --actual-root build/replay --report-root build/replay-diff`
 - `python scripts/ci/check_release_readiness.py`
 - `python scripts/ci/check_config_prompt_menu_glyph_closure.py`
+- `powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1`
 - `xmake build -y DualPadDInput8Proxy`
 - `python scripts/dev/generate_release_artifact_manifest.py --require-build-artifacts --expect-clean`
 - `python3 scripts/dev/setup_graphify_local.py rebuild --reason manual-closeout`

--- a/docs/releases/dp5_rc20_u5_rc_readiness_closeout_zh.md
+++ b/docs/releases/dp5_rc20_u5_rc_readiness_closeout_zh.md
@@ -1,0 +1,87 @@
+# DP5-RC20 U5 RC readiness closeout
+
+本文记录 `DP5-RC20 U5 Verification / observability / governance closeout` 的当前结论。U5 是 RC 外层验证与治理收口，不是新的 runtime phase，不替代 `PH0` - `PH8b` 已冻结的 canonical targets。
+
+## Gate hierarchy
+
+`Phase8 是 canonical base gate`。它继续由 `scripts/ci/run_phase8_ci.ps1` 直接构建并运行同名 canonical runtime targets：
+
+- `DualPadReplayTests`
+- `DualPadInputV2Tests`
+- `DualPadIngressTests`
+- `DualPadPromptSnapshotTests`
+- `DualPadPropertyTests`
+- `DualPadFuzzRegressionTests`
+
+`DualPadPresentationProjectionTests` 仍是 public-surface support proof，不被重新命名为 canonical target。
+
+U5 新增 RC readiness outer gate：`scripts/ci/run_rc_readiness.ps1`。该脚本先调用 `scripts/ci/run_phase8_ci.ps1`，再聚合以下 release-candidate 证明：
+
+- `replay diff`：`DualPadReplayHarness` 生成 `tests/replay/golden/phase0` dispatcher output，再由 `scripts/dev/dualpad_trace_diff.py` 对比。
+- `builder JSON`：校验 `.dualpad-builder/feature_list.json` 与 `.dualpad-builder/sprint_plan.json`。
+- `generated docs`：由 Phase8 内部 `DualPadDocGen` 与 generated docs clean diff 证明。
+- `legacy boundary`：运行 `scripts/ci/check_legacy_authority_boundary.py`。
+- `release readiness`：运行 `scripts/ci/check_release_readiness.py`。
+- `U4 contract gate`：运行 `scripts/ci/check_config_prompt_menu_glyph_closure.py`。
+- `release artifact manifest`：构建 `DualPadDInput8Proxy` 后运行 `scripts/dev/generate_release_artifact_manifest.py --require-build-artifacts`；最终干净提交后用 `--expect-clean` 绑定 final source commit。`--expect-clean` 检查 tracked content diff 与 index diff，不把 generated docs 的 CRLF stat-only 状态误判为 release blocker。
+- `graphify`：运行 `python3 scripts/dev/setup_graphify_local.py rebuild --reason manual-closeout`。
+- diff hygiene：运行 `git diff --check`。
+
+RC outer gate 只能聚合 Phase8、replay、builder memory、graphify、release artifact 与 governance checks；不得把 Phase8 canonical targets 包装成新名字，也不得从 outer gate 反向驱动 Phase8。
+
+## Real-game QA matrix
+
+U5 不把本机手工 QA 写成自动通过项；以下矩阵是 RC 人工验证清单，任何失败都要按 release blocker 处理或显式降级为 non-blocking known limitation。
+
+| Area | Scenario | Expected result | Evidence |
+| --- | --- | --- | --- |
+| 启动 | Game start with DualSense connected | 插件加载，hook/runtime gate 输出明确 supported runtime 结论，首帧不输出 dirty action | `DualPad.log`、debug snapshot |
+| 启动 | Game start without DualSense | HID reader retry open，不输出 dirty input，不刷屏日志 | `DualPad.log` |
+| 存档 | Load save | context / manifest / config generation 保持一致，prompt 不跨旧 scope 解析 | `runtime_debug_snapshot.csv` 或日志 |
+| 存档 | Death / reload | transition frame 后不输出 stale press/release，prompt frozen 或 unavailable 有原因 | replay trace、日志 |
+| 场景切换 | Fast travel / load screen | load screen / gameplay handoff 不重复触发 dirty action | 手工输入记录、日志 |
+| 桌面切换 | Alt-tab / focus loss / regain | focus 恢复后 primary path 重新仲裁，不保留旧 menu cursor owner | 手工 QA 记录 |
+| 设备 | Hot-plug DualSense | open 后 reset live facts、haptics handle 绑定，sequence 从 fresh state 开始 | 日志 |
+| 设备 | Disconnect / reconnect DualSense | disconnect 清空 facts 和 haptics handle，reconnect 不复用 stale state | 日志 |
+| 菜单 | InventoryMenu / MagicMenu / MapMenu / JournalMenu | prompt 与 owner 跟随当前 context，不解析错 glyph | 屏幕检查、日志 |
+| 菜单 | DialogueMenu / ContainerMenu / BookMenu / MessageBoxMenu / Lockpicking | ignored / passthrough / direct binding 分类符合 generated facts | 屏幕检查、generated docs |
+| 菜单 | FavoritesMenu | 只验证 repo-owned action / prompt facts；不恢复页面级 SWF workspace | generated facts、non-restore 记录 |
+| 输入压力 | High-frequency input | ingress queue high-water 未接近容量，overflow count 为 0 或有清晰 transition | debug snapshot |
+| 组合输入 | Long press + menu switch | primary path 和 prompt scope 不交叉污染 | 手工 QA 记录 |
+| 组合输入 | Chord + reload | reload 后 latch invalidated，不输出 dirty chord pulse | replay / focused tests |
+| 图标 | Prompt resolve + config reload | prompt 使用 frame-bound baseline，错误 scope fail-closed | debug snapshot |
+| 图 | Graph reload + context change | `manifestEpoch` / `configGeneration` / `contextRevision` 可定位 skew reason | debug snapshot |
+
+## Performance budget
+
+U5 只定义 RC budget 与可观察指标，不把当前性能优化偷换成 runtime 合同变更。
+
+| Metric | Budget | Release blocker threshold |
+| --- | --- | --- |
+| Stable runtime processing | average <= 0.50 ms/frame, P99 <= 2.00 ms/frame | P99 > 4.00 ms/frame in repeated gameplay QA |
+| Prompt resolve | average <= 0.20 ms, P99 <= 1.00 ms | wrong prompt/glyph 或 P99 > 2.00 ms with log spam |
+| Graph/config reload promotion | <= 100 ms for default config on local debug build | reload causes dirty action or prompt scope mismatch |
+| Ingress queue high-water | < 75% capacity during stress QA | sustained overflow or unbounded backlog |
+| Overflow count | 0 in normal QA; nonzero must have `QueueOverflow` transition and compaction summary | overflow without degraded reason or stale action output |
+| Degraded reason transition count | one log per reason-transition key | per-frame repeated identical degraded logs |
+| Log volume | <= 100 KB/min during normal QA; degraded bursts must settle after transition log | log storm that hides root cause |
+
+`Performance budget` evidence can come from debug snapshot, trace CSV, logs, or profiler notes. If a metric is not currently emitted as a numeric counter, U5 requires the corresponding reason/debug surface to be present so a field report can still isolate the failure path.
+
+## Observability coverage
+
+Current debug snapshot/log surface covers the U5 required failure reasons:
+
+- `RuntimeDebugSnapshot` exposes health reason names: `GraphUnavailable`, `ManifestEpochSkew`, `ContextRevisionSkew`, `QueueOverflow`, `SequenceGap`, `BoundaryMismatch`, `PromptScopeFrozen`, `HookInstallFailed`.
+- Prompt freeze / unavailable state carries `PromptScopeFrozen`, `promptDebugReason`, prompt scope state, `manifestEpoch`, and related prompt baseline facts.
+- `overflow compaction` records retained boundary facts and dropped volatile input summary; `QueueOverflow` is a transition reason, not a silent queue mutation.
+- Hook failure carries install status and debug reason, including unsupported runtime, signature mismatch, failed and partial install paths.
+- Manifest/config/context generation can be correlated through `manifestEpoch`, `configGeneration`, and `contextRevision`.
+- Runtime logs are reason-transition keyed to prevent `log storm` behavior; identical degraded / recovered snapshots are deduplicated.
+- Optional `runtime_debug_snapshot.csv` from replay/debug tracing is additive and does not become Phase0 golden required schema.
+
+## Governance closeout
+
+旧 #5 `GameplayKbmFactTracker` ControlMap lookup cleanup is retained as U5 `non-authority cleanup`: it does not own `input_v2` core runtime decisions and is not a release blocker while the legacy boundary static gate and RC performance budget hold. Future hot-path cleanup can be tracked separately if profiling shows a budget breach.
+
+U5 closeout updates #12 and #13 with the RC outer gate, real-game QA matrix, performance budget and observability evidence. `DP5-RC20` child governance issues are closed only after the RC outer gate passes against the final source commit.

--- a/docs/superpowers/plans/2026-06-08-dp5-rc20-u5-verification-observability-governance.md
+++ b/docs/superpowers/plans/2026-06-08-dp5-rc20-u5-verification-observability-governance.md
@@ -1,0 +1,97 @@
+# DP5-RC20 U5 Verification / Observability / Governance Closeout 实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
+
+**目标：** 在 U4 merge commit `356837d6b0c51c01671a4f7f273932347d435a91` 之后，为 DP5-RC20 建立 RC readiness outer gate，并关闭 U5 的验证、可观察性和治理记录。
+
+**架构：** Phase8 继续作为 canonical base gate，U5 只在外层聚合 replay diff、builder JSON、graphify、release readiness、U4 gate、artifact manifest 和 hygiene checks。Reviewed docs 记录 QA matrix、performance budget 与 debug surface 覆盖；static guard 防止 U5 gate 漂移。
+
+**技术栈：** PowerShell、Python static checks、xmake、graphify、GitHub CLI、中文 reviewed docs。
+
+---
+
+## 文件结构
+
+- 创建：`scripts/ci/run_rc_readiness.ps1`，RC readiness outer gate。
+- 创建：`scripts/ci/check_rc_readiness_closeout.py`，U5 静态治理检查。
+- 创建：`docs/releases/dp5_rc20_u5_rc_readiness_closeout_zh.md`，U5 reviewed closeout 文档。
+- 修改：`scripts/ci/check_reviewed_docs_consistency.py`，要求 U5 gate 和文档存在。
+- 修改：`scripts/dev/generate_release_artifact_manifest.py`，让 `--expect-clean` 使用 tracked content diff，避免 generated docs 行尾状态假失败。
+- 修改：`docs/authoritative-baseline/dp5_rc20_contract_zh.md`，接入 U5 合同。
+- 修改：`docs/authoritative-baseline/work-packages/README.md`，记录 U4 merge 与 U5 closeout。
+- 修改：`docs/DOC_INDEX_zh.md`，索引 U5 文档。
+- 修改：`.dualpad-builder/feature_list.json`、`.dualpad-builder/sprint_plan.json`、`.dualpad-builder/progress.md`，同步 builder memory。
+
+### 任务 1：建立 RC outer gate
+
+- [x] **步骤 1：创建 `scripts/ci/run_rc_readiness.ps1`**
+
+```powershell
+Invoke-Step powershell @("-ExecutionPolicy", "Bypass", "-File", "scripts/ci/run_phase8_ci.ps1")
+Invoke-Step xmake @("build", "-y", "DualPadReplayHarness")
+Invoke-Step python @("scripts/dev/dualpad_trace_diff.py", "--batch", "tests/replay/golden/phase0", "--actual-root", "build/replay", "--report-root", "build/replay-diff")
+Invoke-Step python @("scripts/ci/check_rc_readiness_closeout.py")
+Invoke-Step python3 @("scripts/dev/setup_graphify_local.py", "rebuild", "--reason", "manual-closeout")
+```
+
+- [x] **步骤 2：创建 `scripts/ci/check_rc_readiness_closeout.py`**
+
+```python
+require_tokens(failures, "scripts/ci/run_rc_readiness.ps1", ["scripts/ci/run_phase8_ci.ps1", "DualPadReplayHarness"])
+```
+
+### 任务 2：记录 U5 closeout truth
+
+- [x] **步骤 1：创建 U5 reviewed 文档**
+
+```markdown
+## Gate hierarchy
+
+`Phase8 是 canonical base gate`。
+```
+
+- [x] **步骤 2：接入 baseline 和文档索引**
+
+运行：`python scripts/ci/check_rc_readiness_closeout.py`
+预期：新增文档和索引 token 都能被 static guard 找到。
+
+### 任务 3：同步 builder memory 与 GitHub governance
+
+- [x] **步骤 1：更新 `.dualpad-builder/feature_list.json` 和 `.dualpad-builder/sprint_plan.json`**
+
+预期：`DP5` / `S-DP5` 继续是 planned post-closeout backlog，但 acceptance / verification 记录 U5 closeout gate。
+
+- [x] **步骤 2：追加 `.dualpad-builder/progress.md`**
+
+预期：记录 PR #20 merge commit、U5 分支和 U5 start / implementation surface。
+
+- [ ] **步骤 3：验证通过后更新 #12、#13，并同步 #8 closed status**
+
+运行：`gh issue edit` / `gh issue close`
+预期：#12 和 #13 记录 U5 gate 证据；#8 不再在 #13 中显示为未完成。
+
+### 任务 4：验证与收口
+
+- [ ] **步骤 1：运行 static / JSON checks**
+
+运行：
+
+```powershell
+python scripts/ci/check_rc_readiness_closeout.py
+python scripts/ci/check_reviewed_docs_consistency.py
+python -m json.tool .dualpad-builder/feature_list.json
+python -m json.tool .dualpad-builder/sprint_plan.json
+```
+
+预期：全部 exit 0。
+
+- [ ] **步骤 2：运行 Phase8 和 RC readiness gate**
+
+运行：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/ci/run_phase8_ci.ps1
+powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1
+```
+
+预期：全部 exit 0。最终提交后重跑 `run_rc_readiness.ps1 -ExpectCleanManifest`，让 artifact manifest 绑定 final source commit。

--- a/scripts/ci/check_rc_readiness_closeout.py
+++ b/scripts/ci/check_rc_readiness_closeout.py
@@ -1,0 +1,156 @@
+"""Fail CI when DP5-RC20 U5 RC readiness closeout drifts."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+U5_DOC = ROOT / "docs/releases/dp5_rc20_u5_rc_readiness_closeout_zh.md"
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def require_tokens(failures: list[str], relative: str, tokens: list[str]) -> None:
+    text = read(relative)
+    for token in tokens:
+        if token not in text:
+            failures.append(f"{relative}: missing required token {token!r}")
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    if not U5_DOC.is_file():
+        failures.append("docs/releases/dp5_rc20_u5_rc_readiness_closeout_zh.md: missing U5 closeout doc.")
+    else:
+        require_tokens(
+            failures,
+            "docs/releases/dp5_rc20_u5_rc_readiness_closeout_zh.md",
+            [
+                "DP5-RC20 U5",
+                "Phase8 是 canonical base gate",
+                "scripts/ci/run_rc_readiness.ps1",
+                "scripts/ci/run_phase8_ci.ps1",
+                "DualPadReplayTests",
+                "DualPadInputV2Tests",
+                "DualPadIngressTests",
+                "DualPadPromptSnapshotTests",
+                "DualPadPropertyTests",
+                "DualPadFuzzRegressionTests",
+                "DualPadPresentationProjectionTests",
+                "replay diff",
+                "graphify",
+                "builder JSON",
+                "generated docs",
+                "legacy boundary",
+                "release readiness",
+                "U4 contract gate",
+                "release artifact manifest",
+                "Real-game QA matrix",
+                "Performance budget",
+                "RuntimeDebugSnapshot",
+                "GraphUnavailable",
+                "ManifestEpochSkew",
+                "ContextRevisionSkew",
+                "QueueOverflow",
+                "SequenceGap",
+                "BoundaryMismatch",
+                "PromptScopeFrozen",
+                "HookInstallFailed",
+                "overflow compaction",
+                "manifestEpoch",
+                "configGeneration",
+                "contextRevision",
+                "reason-transition",
+                "log storm",
+                "旧 #5",
+                "non-authority cleanup",
+            ],
+        )
+
+    require_tokens(
+        failures,
+        "scripts/ci/run_rc_readiness.ps1",
+        [
+            "scripts/ci/run_phase8_ci.ps1",
+            "DualPadReplayHarness",
+            "scripts/dev/dualpad_trace_diff.py",
+            ".dualpad-builder/feature_list.json",
+            ".dualpad-builder/sprint_plan.json",
+            "scripts/ci/check_reviewed_docs_consistency.py",
+            "scripts/ci/check_legacy_authority_boundary.py",
+            "scripts/ci/check_release_readiness.py",
+            "scripts/ci/check_config_prompt_menu_glyph_closure.py",
+            "scripts/ci/check_rc_readiness_closeout.py",
+            "DualPadDInput8Proxy",
+            "scripts/dev/generate_release_artifact_manifest.py",
+            "--require-build-artifacts",
+            "--expect-clean",
+            "scripts/dev/setup_graphify_local.py",
+            "git",
+            "diff",
+            "--check",
+        ],
+    )
+
+    phase8 = read("scripts/ci/run_phase8_ci.ps1")
+    for target in [
+        "DualPadReplayTests",
+        "DualPadInputV2Tests",
+        "DualPadIngressTests",
+        "DualPadPromptSnapshotTests",
+        "DualPadPropertyTests",
+        "DualPadFuzzRegressionTests",
+    ]:
+        if target not in phase8:
+            failures.append(f"scripts/ci/run_phase8_ci.ps1: Phase8 must still reference canonical target {target}.")
+
+    if "scripts/ci/run_rc_readiness.ps1" in phase8:
+        failures.append("scripts/ci/run_phase8_ci.ps1: Phase8 must not call the RC outer gate.")
+
+    require_tokens(
+        failures,
+        "scripts/ci/check_reviewed_docs_consistency.py",
+        [
+            "scripts/ci/run_rc_readiness.ps1",
+            "docs/releases/dp5_rc20_u5_rc_readiness_closeout_zh.md",
+        ],
+    )
+    require_tokens(
+        failures,
+        "docs/authoritative-baseline/dp5_rc20_contract_zh.md",
+        [
+            "U5 Verification / Observability / Governance Closeout",
+            "Phase8 是 canonical base gate",
+            "RC readiness outer gate",
+            "Real-game QA matrix",
+            "Performance budget",
+        ],
+    )
+    require_tokens(
+        failures,
+        "docs/DOC_INDEX_zh.md",
+        ["releases/dp5_rc20_u5_rc_readiness_closeout_zh.md"],
+    )
+    require_tokens(
+        failures,
+        "docs/authoritative-baseline/work-packages/README.md",
+        ["U5：verification / observability / governance closeout 已完成"],
+    )
+
+    if failures:
+        print("RC readiness closeout check failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("RC readiness closeout check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_reviewed_docs_consistency.py
+++ b/scripts/ci/check_reviewed_docs_consistency.py
@@ -110,6 +110,25 @@ def main() -> int:
     if "scripts/ci/check_config_prompt_menu_glyph_closure.py" not in phase8_ci:
         failures.append("scripts/ci/run_phase8_ci.ps1: default CI must run config/prompt/menu/glyph closure check.")
 
+    rc_gate = (ROOT / "scripts/ci/run_rc_readiness.ps1").read_text(encoding="utf-8")
+    for marker in [
+        "scripts/ci/run_phase8_ci.ps1",
+        "DualPadReplayHarness",
+        "scripts/dev/dualpad_trace_diff.py",
+        "scripts/ci/check_legacy_authority_boundary.py",
+        "scripts/ci/check_release_readiness.py",
+        "scripts/ci/check_config_prompt_menu_glyph_closure.py",
+        "scripts/ci/check_rc_readiness_closeout.py",
+        "scripts/dev/generate_release_artifact_manifest.py",
+        "scripts/dev/setup_graphify_local.py",
+    ]:
+        if marker not in rc_gate:
+            failures.append(f"scripts/ci/run_rc_readiness.ps1: RC outer gate missing marker {marker}.")
+    u5_doc = (ROOT / "docs/releases/dp5_rc20_u5_rc_readiness_closeout_zh.md").read_text(encoding="utf-8")
+    for marker in ["Phase8 是 canonical base gate", "Real-game QA matrix", "Performance budget", "RuntimeDebugSnapshot"]:
+        if marker not in u5_doc:
+            failures.append(f"docs/releases/dp5_rc20_u5_rc_readiness_closeout_zh.md: missing U5 marker {marker}.")
+
     feature_data = json.loads((ROOT / ".dualpad-builder/feature_list.json").read_text(encoding="utf-8"))
     features = {item["id"]: item for item in feature_data["features"]}
     for feature_id in ["DP1", "DP2", "DP3", "DP4", "PH0", "PH1", "PH2", "PH3", "PH4", "PH5", "PH6", "PH7", "PH8", "PH8a", "PH8b"]:

--- a/scripts/ci/run_rc_readiness.ps1
+++ b/scripts/ci/run_rc_readiness.ps1
@@ -1,0 +1,66 @@
+param(
+    [switch] $ExpectCleanManifest
+)
+
+$ErrorActionPreference = "Stop"
+
+Set-StrictMode -Version Latest
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Command,
+        [Parameter(Mandatory = $true)]
+        [string[]] $Arguments
+    )
+
+    Write-Host "==> $Command $($Arguments -join ' ')"
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "command failed: $Command $($Arguments -join ' ')"
+    }
+}
+
+Invoke-Step powershell @("-ExecutionPolicy", "Bypass", "-File", "scripts/ci/run_phase8_ci.ps1")
+
+Invoke-Step xmake @("build", "-y", "DualPadReplayHarness")
+Invoke-Step xmake @(
+    "run",
+    "-y",
+    "DualPadReplayHarness",
+    "--",
+    "--batch",
+    "tests/replay/golden/phase0",
+    "--mode",
+    "dispatcher",
+    "--output-root",
+    "build/replay"
+)
+Invoke-Step python @(
+    "scripts/dev/dualpad_trace_diff.py",
+    "--batch",
+    "tests/replay/golden/phase0",
+    "--actual-root",
+    "build/replay",
+    "--report-root",
+    "build/replay-diff"
+)
+
+Invoke-Step python @("-m", "json.tool", ".dualpad-builder/feature_list.json", "NUL")
+Invoke-Step python @("-m", "json.tool", ".dualpad-builder/sprint_plan.json", "NUL")
+Invoke-Step python @("scripts/ci/check_reviewed_docs_consistency.py")
+Invoke-Step python @("scripts/ci/check_legacy_authority_boundary.py")
+Invoke-Step python @("scripts/ci/check_release_readiness.py")
+Invoke-Step python @("scripts/ci/check_config_prompt_menu_glyph_closure.py")
+Invoke-Step python @("scripts/ci/check_rc_readiness_closeout.py")
+
+Invoke-Step xmake @("build", "-y", "DualPadDInput8Proxy")
+
+$manifestArgs = @("scripts/dev/generate_release_artifact_manifest.py", "--require-build-artifacts")
+if ($ExpectCleanManifest) {
+    $manifestArgs += "--expect-clean"
+}
+Invoke-Step python $manifestArgs
+
+Invoke-Step python3 @("scripts/dev/setup_graphify_local.py", "rebuild", "--reason", "manual-closeout")
+Invoke-Step git @("diff", "--check")

--- a/scripts/dev/generate_release_artifact_manifest.py
+++ b/scripts/dev/generate_release_artifact_manifest.py
@@ -50,6 +50,12 @@ def run_git(args: list[str]) -> str:
     return subprocess.check_output(["git", *args], cwd=ROOT, text=True).strip()
 
 
+def tracked_content_dirty() -> bool:
+    worktree = subprocess.run(["git", "diff", "--quiet", "--"], cwd=ROOT, check=False)
+    index = subprocess.run(["git", "diff", "--cached", "--quiet", "--"], cwd=ROOT, check=False)
+    return worktree.returncode != 0 or index.returncode != 0
+
+
 def sha256(path: pathlib.Path) -> str | None:
     full = ROOT / path
     if not full.is_file():
@@ -88,7 +94,7 @@ def collect_runtime_artifacts() -> list[dict[str, Any]]:
 def manifest() -> dict[str, Any]:
     commit = run_git(["rev-parse", "HEAD"])
     branch = run_git(["branch", "--show-current"])
-    dirty = run_git(["status", "--porcelain", "--untracked-files=no"]) != ""
+    dirty = tracked_content_dirty()
 
     files = []
     files.extend(collect_runtime_artifacts())


### PR DESCRIPTION
## Summary
- Add RC readiness outer gate around Phase8 canonical CI
- Document real-game QA matrix, performance budget, observability coverage, and governance closeout
- Keep Phase8 as canonical base gate without renaming or replacing canonical targets
- Fix release artifact manifest clean detection to use tracked content diff instead of CRLF-sensitive porcelain status

## Verification
- python scripts/ci/check_rc_readiness_closeout.py
- python scripts/ci/check_reviewed_docs_consistency.py
- python -m json.tool .dualpad-builder/feature_list.json NUL
- python -m json.tool .dualpad-builder/sprint_plan.json NUL
- powershell -ExecutionPolicy Bypass -File scripts/ci/run_phase8_ci.ps1
- powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1
- powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1 -ExpectCleanManifest