### PR TITLE
Fix menu glyph delegate reattach

### DIFF
--- a/.dualpad-builder/progress.md
+++ b/.dualpad-builder/progress.md
@@ -2665,3 +2665,31 @@
     - `rc-readiness`：pass，run `27373385092` job `80892545879`，`https://github.com/airoucat/dualpad/actions/runs/27373385092/job/80892545879`。
 - 备注：
   - 本条为 evidence-only progress 更新；推送后需确认最后一轮 PR #22 checks 仍为 green。
+
+## 2026-06-12 04:35:00 CST
+
+- PR-B1 start：MainMenu / menu glyph delegate reattach fix。
+- 分支：`codex/dp5-rc20-menu-glyph-reattach-fix`，从 PR-A merge 后的 `main` 创建。
+- 范围：
+  - `ContextEventSink` 在 `MenuOpenCloseEvent` 后通知 `ScaleformGlyphBridge::OnMenuOpened` / `OnMenuClosed`。
+  - `ScaleformGlyphBridge` 继续仅作为 facade 转发到 `ScaleformPromptAdapter`。
+  - `ScaleformPromptAdapter` 将 delegate 注册记录改为 per-menu pointer map，菜单关闭时只清理记录，不访问旧 delegate / 不反注册。
+  - U4 static gate 增加 menu glyph lifecycle / per-menu delegate map marker。
+- 待验证：
+  - `python scripts/ci/check_config_prompt_menu_glyph_closure.py`
+  - `powershell -ExecutionPolicy Bypass -File scripts/ci/run_phase8_ci.ps1`
+  - `powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1 -ExpectCleanManifest`
+  - `git diff --check`
+
+## 2026-06-12 04:50:00 CST
+
+- PR-B1 本地验证：
+  - `python scripts/ci/check_config_prompt_menu_glyph_closure.py`：exit 0。
+  - `xmake build -y DualPadPromptSnapshotTests`：exit 0。
+  - `xmake run -y DualPadPromptSnapshotTests`：exit 0。
+  - `xmake build -y DualPad`：exit 0；覆盖 `ContextEventSink`、`ScaleformGlyphBridge`、`ScaleformPromptAdapter` 与 replay stub 编译面。
+  - `powershell -ExecutionPolicy Bypass -File scripts/ci/run_phase8_ci.ps1`：exit 0；覆盖 canonical Phase8 targets、DocGen、reviewed docs consistency、legacy boundary、release readiness、U4 closure gate 与 generated docs diff。
+  - `git diff --check`：exit 0；仅 Windows 行尾提示，无 whitespace error。
+- 待验证：
+  - 本条提交后运行 `powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1 -ExpectCleanManifest`。
+  - 推送后远端 PR-B1 `phase8` / `rc-readiness`。

--- a/.dualpad-builder/progress.md
+++ b/.dualpad-builder/progress.md
@@ -2693,3 +2693,12 @@
 - 待验证：
   - 本条提交后运行 `powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1 -ExpectCleanManifest`。
   - 推送后远端 PR-B1 `phase8` / `rc-readiness`。
+
+## 2026-06-12 05:05:00 CST
+
+- PR-B1 本地 RC 验证：
+  - Head commit: `535a3d7`。
+  - `powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1 -ExpectCleanManifest`：exit 0。
+  - 覆盖 Phase8、`DualPadManifestCompilerTests`、phase0 dispatcher replay 10 个 scenario `no diff`、builder JSON、reviewed docs consistency、legacy boundary、release readiness、U4 closure gate（含 B1 menu glyph lifecycle static markers）、U5 RC closeout static gate、`DualPadDInput8Proxy` build、`DP5-RC20-release-artifact-manifest.{json,md}` clean manifest check、graphify manual-closeout rebuild 与 `git diff --check`。
+- 待验证：
+  - 推送后远端 PR-B1 `phase8` / `rc-readiness`。

--- a/scripts/ci/check_config_prompt_menu_glyph_closure.py
+++ b/scripts/ci/check_config_prompt_menu_glyph_closure.py
@@ -141,6 +141,43 @@ def main() -> int:
     if "scripts/ci/check_config_prompt_menu_glyph_closure.py" not in reviewed_lint:
         failures.append("scripts/ci/check_reviewed_docs_consistency.py: reviewed docs lint must require the U4 closure check.")
 
+    context_event_sink = read("src/input/ContextEventSink.cpp")
+    for marker in [
+        "ScaleformGlyphBridge::GetSingleton",
+        "glyphBridge.OnMenuOpened",
+        "glyphBridge.OnMenuClosed",
+    ]:
+        if marker not in context_event_sink:
+            failures.append(f"src/input/ContextEventSink.cpp: missing menu glyph lifecycle marker {marker!r}.")
+
+    scaleform_bridge_h = read("src/input/glyph/ScaleformGlyphBridge.h")
+    scaleform_bridge_cpp = read("src/input/glyph/ScaleformGlyphBridge.cpp")
+    for relative, text in [
+        ("src/input/glyph/ScaleformGlyphBridge.h", scaleform_bridge_h),
+        ("src/input/glyph/ScaleformGlyphBridge.cpp", scaleform_bridge_cpp),
+    ]:
+        if "OnMenuClosed" not in text:
+            failures.append(f"{relative}: missing OnMenuClosed forwarding surface.")
+
+    scaleform_adapter_h = read("src/input_v2/prompt/ScaleformPromptAdapter.h")
+    scaleform_adapter_cpp = read("src/input_v2/prompt/ScaleformPromptAdapter.cpp")
+    for marker in [
+        "OnMenuClosed",
+        "_registeredDelegatesByMenu",
+        "std::unordered_map<std::string, std::uintptr_t>",
+    ]:
+        if marker not in scaleform_adapter_h:
+            failures.append(f"src/input_v2/prompt/ScaleformPromptAdapter.h: missing per-menu delegate marker {marker!r}.")
+    for marker in [
+        "_registeredDelegatesByMenu.find(menuKey)",
+        "_registeredDelegatesByMenu.erase(menu)",
+        "_registeredDelegatesByMenu[menuKey] = delegateKey",
+    ]:
+        if marker not in scaleform_adapter_cpp:
+            failures.append(f"src/input_v2/prompt/ScaleformPromptAdapter.cpp: missing per-menu delegate lifecycle marker {marker!r}.")
+    if "_registeredDelegates.contains(delegateKey)" in scaleform_adapter_cpp:
+        failures.append("src/input_v2/prompt/ScaleformPromptAdapter.cpp: must not use a global delegate pointer set as the only reattach guard.")
+
     if failures:
         print("config/prompt/menu/glyph closure check failed:")
         for failure in failures:

--- a/src/input/ContextEventSink.cpp
+++ b/src/input/ContextEventSink.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "input/ContextEventSink.h"
+#include "input/glyph/ScaleformGlyphBridge.h"
 #include "input_v2/context/ContextRefreshTick.h"
 #include "input_v2/menu/UiMenuObserver.h"
 
@@ -67,6 +68,14 @@ namespace dualpad::input
 
         auto& observer = dualpad::input_v2::menu::UiMenuObserver::GetSingleton();
         observer.MarkMenuEvent(event->menuName.c_str(), event->opening);
+
+        auto& glyphBridge = dualpad::input::glyph::ScaleformGlyphBridge::GetSingleton();
+        if (event->opening) {
+            glyphBridge.OnMenuOpened(event->menuName.c_str());
+        }
+        else {
+            glyphBridge.OnMenuClosed(event->menuName.c_str());
+        }
 
         return RE::BSEventNotifyControl::kContinue;
     }

--- a/src/input/glyph/ScaleformGlyphBridge.cpp
+++ b/src/input/glyph/ScaleformGlyphBridge.cpp
@@ -24,6 +24,11 @@ namespace dualpad::input::glyph
         input_v2::prompt::ScaleformPromptAdapter::GetSingleton().OnMenuOpened(menuName);
     }
 
+    void ScaleformGlyphBridge::OnMenuClosed(std::string_view menuName)
+    {
+        input_v2::prompt::ScaleformPromptAdapter::GetSingleton().OnMenuClosed(menuName);
+    }
+
     GlyphResolutionCompatResult ScaleformGlyphBridge::ReplayResolveActionGlyph(
         std::string_view actionId,
         std::string_view contextName)

--- a/src/input/glyph/ScaleformGlyphBridge.h
+++ b/src/input/glyph/ScaleformGlyphBridge.h
@@ -17,6 +17,7 @@ namespace dualpad::input::glyph
 
         void RegisterInitialMenus();
         void OnMenuOpened(std::string_view menuName);
+        void OnMenuClosed(std::string_view menuName);
         GlyphResolutionCompatResult ReplayResolveActionGlyph(
             std::string_view actionId,
             std::string_view contextName);

--- a/src/input_v2/prompt/ScaleformPromptAdapter.cpp
+++ b/src/input_v2/prompt/ScaleformPromptAdapter.cpp
@@ -83,6 +83,16 @@ namespace dualpad::input_v2::prompt
         }
     }
 
+    void ScaleformPromptAdapter::OnMenuClosed(std::string_view menuName)
+    {
+        const auto menu = std::string(menuName);
+        std::scoped_lock lock(_mutex);
+        const auto removed = _registeredDelegatesByMenu.erase(menu);
+        if (removed != 0) {
+            logger::info("[DualPad][PromptAdapter] Cleared GameDelegate prompt handler record for {}", menu);
+        }
+    }
+
     std::string ScaleformPromptAdapter::ResolveLegacyGlyphTokenForRuntime(
         std::string_view actionId,
         std::string_view contextName)
@@ -222,13 +232,15 @@ namespace dualpad::input_v2::prompt
         }
 
         const auto delegateKey = reinterpret_cast<std::uintptr_t>(menu->fxDelegate.get());
+        const auto menuKey = std::string(menuName);
         {
             std::scoped_lock lock(_mutex);
-            if (_registeredDelegates.contains(delegateKey)) {
+            const auto registered = _registeredDelegatesByMenu.find(menuKey);
+            if (registered != _registeredDelegatesByMenu.end() && registered->second == delegateKey) {
                 return true;
             }
             menu->fxDelegate->RegisterHandler(this);
-            _registeredDelegates.insert(delegateKey);
+            _registeredDelegatesByMenu[menuKey] = delegateKey;
         }
 
         logger::info("[DualPad][PromptAdapter] Registered GameDelegate prompt handler for {}", menuName);

--- a/src/input_v2/prompt/ScaleformPromptAdapter.h
+++ b/src/input_v2/prompt/ScaleformPromptAdapter.h
@@ -7,7 +7,7 @@
 #include <mutex>
 #include <string>
 #include <string_view>
-#include <unordered_set>
+#include <unordered_map>
 
 namespace dualpad::input::glyph
 {
@@ -23,6 +23,7 @@ namespace dualpad::input_v2::prompt
 
         void RegisterInitialMenus();
         void OnMenuOpened(std::string_view menuName);
+        void OnMenuClosed(std::string_view menuName);
 
         [[nodiscard]] std::string ResolveLegacyGlyphTokenForRuntime(
             std::string_view actionId,
@@ -45,6 +46,6 @@ namespace dualpad::input_v2::prompt
         bool AttachToMenu(std::string_view menuName);
 
         std::mutex _mutex;
-        std::unordered_set<std::uintptr_t> _registeredDelegates;
+        std::unordered_map<std::string, std::uintptr_t> _registeredDelegatesByMenu;
     };
 }

--- a/src/input_v2/telemetry/ScaleformGlyphBridgeReplayStub.cpp
+++ b/src/input_v2/telemetry/ScaleformGlyphBridgeReplayStub.cpp
@@ -20,6 +20,10 @@ namespace dualpad::input::glyph
     {
     }
 
+    void ScaleformGlyphBridge::OnMenuClosed(std::string_view)
+    {
+    }
+
     GlyphResolutionCompatResult ScaleformGlyphBridge::ReplayResolveActionGlyph(
         std::string_view actionId,
         std::string_view contextName)


### PR DESCRIPTION
## Summary
- route menu open/close events from ContextEventSink into the glyph bridge lifecycle
- change ScaleformPromptAdapter delegate tracking from a global delegate pointer set to a per-menu delegate map
- add U4 static gate coverage for menu glyph lifecycle and per-menu reattach markers

## Verification
- python scripts/ci/check_config_prompt_menu_glyph_closure.py
- xmake build -y DualPadPromptSnapshotTests
- xmake run -y DualPadPromptSnapshotTests
- xmake build -y DualPad
- powershell -ExecutionPolicy Bypass -File scripts/ci/run_phase8_ci.ps1
- powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1 -ExpectCleanManifest
- git diff --check