### PR TITLE
fix: fail closed on broken ini imports

### DIFF
--- a/.dualpad-builder/progress.md
+++ b/.dualpad-builder/progress.md
@@ -2722,3 +2722,7 @@
 ## 2026-06-12 05:46:00 +08:00
 
 - PR-B3 本地验证通过。Head commit: `abe30d5`。已先执行 TDD 红测：`xmake build -y DualPadManifestCompilerTests; xmake run -y DualPadManifestCompilerTests` 失败于 `existing bindings file with entry before section must fail import`，确认旧行为会把破损 existing INI 静默当空配置处理。实现后 focused green：`xmake build -y DualPadManifestCompilerTests; xmake run -y DualPadManifestCompilerTests` exit 0。完整 gate：`powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1 -ExpectCleanManifest` exit 0，覆盖 Phase8、`DualPadManifestCompilerTests` build/run、phase0 dispatcher replay 10 个 scenario no diff、builder JSON、reviewed docs consistency、legacy boundary、release readiness、U4 closure、U5 closeout、`DualPadDInput8Proxy` build、DP5-RC20 release artifact manifest clean check、graphify manual-closeout rebuild 与 `git diff --check`。待验证：推送后远端 PR-B3 `phase8` / `rc-readiness`。
+
+## 2026-06-12 06:11:00 +08:00
+
+- PR-B3 远端验证通过：PR #25 https://github.com/airoucat/dualpad/pull/25，head `a8fcaf2713cfdc41be704a93818823a114fa9833`。远端 checks：push `phase8` run `27379474743` job `80912184185` pass；push `rc-readiness` run `27379474743` job `80913581414` pass；pull_request `phase8` run `27379485298` job `80912221999` pass；pull_request `rc-readiness` run `27379485298` job `80913439616` pass。待处理：推送本 evidence 记录后等待最终 checks，再 merge PR-B3。

--- a/.dualpad-builder/progress.md
+++ b/.dualpad-builder/progress.md
@@ -2714,3 +2714,7 @@
 ## 2026-06-12 05:21:02 +08:00
 
 - PR-B2 远端验证通过：PR #24 https://github.com/airoucat/dualpad/pull/24，head a6e74dc。远端 checks：push phase8 run 27377256038 job 80904601807 pass；push rc-readiness run 27377256038 job 80906081844 pass；pull_request phase8 run 27377273931 job 80904662615 pass；pull_request rc-readiness run 27377273931 job 80906257898 pass。待处理：推送本 evidence 记录后等待最终 checks，再 merge PR-B2。
+
+## 2026-06-12 05:39:39 +08:00
+
+- PR-B2 已合入 main：PR #24 merge commit 8411a0d4a1bcd0635b3422ebdc8c15c2015828c2。开始 PR-B3 broken INI fail-closed：分支 codex/dp5-rc20-broken-ini-fail-closed。范围：LegacyIniImporter 区分 missing 与 existing-but-unreadable/broken；两份主配置 missing 仍允许 built-in defaults；存在但打不开、缺 '='、section 前 key 或 bindings 空 AST 必须可见失败并阻止静默当空配置成功。先补红测，待验证。

--- a/.dualpad-builder/progress.md
+++ b/.dualpad-builder/progress.md
@@ -2718,3 +2718,7 @@
 ## 2026-06-12 05:39:39 +08:00
 
 - PR-B2 已合入 main：PR #24 merge commit 8411a0d4a1bcd0635b3422ebdc8c15c2015828c2。开始 PR-B3 broken INI fail-closed：分支 codex/dp5-rc20-broken-ini-fail-closed。范围：LegacyIniImporter 区分 missing 与 existing-but-unreadable/broken；两份主配置 missing 仍允许 built-in defaults；存在但打不开、缺 '='、section 前 key 或 bindings 空 AST 必须可见失败并阻止静默当空配置成功。先补红测，待验证。
+
+## 2026-06-12 05:46:00 +08:00
+
+- PR-B3 本地验证通过。Head commit: `abe30d5`。已先执行 TDD 红测：`xmake build -y DualPadManifestCompilerTests; xmake run -y DualPadManifestCompilerTests` 失败于 `existing bindings file with entry before section must fail import`，确认旧行为会把破损 existing INI 静默当空配置处理。实现后 focused green：`xmake build -y DualPadManifestCompilerTests; xmake run -y DualPadManifestCompilerTests` exit 0。完整 gate：`powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1 -ExpectCleanManifest` exit 0，覆盖 Phase8、`DualPadManifestCompilerTests` build/run、phase0 dispatcher replay 10 个 scenario no diff、builder JSON、reviewed docs consistency、legacy boundary、release readiness、U4 closure、U5 closeout、`DualPadDInput8Proxy` build、DP5-RC20 release artifact manifest clean check、graphify manual-closeout rebuild 与 `git diff --check`。待验证：推送后远端 PR-B3 `phase8` / `rc-readiness`。

--- a/src/input_v2/config/AtomicConfigReloader.cpp
+++ b/src/input_v2/config/AtomicConfigReloader.cpp
@@ -337,6 +337,23 @@ namespace dualpad::input_v2::config
                 return false;
             }
         };
+
+        std::string WarningSummary(const std::vector<std::string>& warnings)
+        {
+            if (warnings.empty()) {
+                return {};
+            }
+
+            std::ostringstream out;
+            out << "warnings: ";
+            for (std::size_t i = 0; i < warnings.size(); ++i) {
+                if (i != 0) {
+                    out << " | ";
+                }
+                out << warnings[i];
+            }
+            return out.str();
+        }
     }
 
     AtomicConfigReloader& AtomicConfigReloader::GetSingleton()
@@ -469,7 +486,7 @@ namespace dualpad::input_v2::config
 
             LoadOrRecoverResult r{};
             r.ok = true;
-            r.message = "ok";
+            r.message = scratch.message;
             return r;
         }
 
@@ -556,6 +573,9 @@ namespace dualpad::input_v2::config
             result.message = std::string("import failed: ") + importResult.message;
             return result;
         }
+        for (const auto& warning : importResult.bundle.warnings) {
+            logger::warn("[DualPad][PH1][Importer] {}", warning);
+        }
 
         const auto importedValidation = ManifestValidator::ValidateImportedAst(importResult.bundle);
         if (!importedValidation.ok) {
@@ -592,7 +612,7 @@ namespace dualpad::input_v2::config
         }
 
         result.ok = true;
-        result.message = "ok";
+        result.message = importResult.bundle.warnings.empty() ? "ok" : std::string("ok; ") + WarningSummary(importResult.bundle.warnings);
         result.bundle = std::move(bundle);
         return result;
     }

--- a/src/input_v2/config/LegacyIniImporter.cpp
+++ b/src/input_v2/config/LegacyIniImporter.cpp
@@ -5,25 +5,69 @@
 #include "input/IniParseHelpers.h"
 
 #include <fstream>
+#include <sstream>
 
 namespace dualpad::input_v2::config
 {
     namespace
     {
+        enum class IniParseRole
+        {
+            Bindings = 0,
+            MenuPolicy
+        };
+
+        struct ParsedIniFile
+        {
+            bool ok{ true };
+            bool opened{ false };
+            bool hadNonCommentContent{ false };
+            std::vector<ImportedSection> sections;
+            std::vector<std::string> warnings;
+            std::string message{ "ok" };
+        };
+
         void AddWarning(std::vector<std::string>& warnings, std::string message)
         {
             warnings.push_back(std::move(message));
         }
 
-        std::vector<ImportedSection> ParseIniFile(const std::filesystem::path& path, std::vector<std::string>& warnings)
+        void AddParseIssue(ParsedIniFile& parsed, std::string message, bool fatal)
         {
-            std::ifstream in(path);
-            if (!in.is_open()) {
-                AddWarning(warnings, std::string("failed to open ini: ") + path.string());
+            AddWarning(parsed.warnings, message);
+            if (fatal && parsed.ok) {
+                parsed.ok = false;
+                parsed.message = std::move(message);
+            }
+        }
+
+        std::string WarningSummary(const std::vector<std::string>& warnings)
+        {
+            if (warnings.empty()) {
                 return {};
             }
 
-            std::vector<ImportedSection> sections;
+            std::ostringstream out;
+            out << "warnings: ";
+            for (std::size_t i = 0; i < warnings.size(); ++i) {
+                if (i != 0) {
+                    out << " | ";
+                }
+                out << warnings[i];
+            }
+            return out.str();
+        }
+
+        ParsedIniFile ParseIniFile(const std::filesystem::path& path, IniParseRole role)
+        {
+            ParsedIniFile parsed{};
+            std::ifstream in(path);
+            if (!in.is_open()) {
+                AddParseIssue(parsed, std::string("failed to open ini: ") + path.string(), true);
+                return parsed;
+            }
+            parsed.opened = true;
+
             ImportedSection* current = nullptr;
 
             std::string line;
@@ -43,24 +87,31 @@ namespace dualpad::input_v2::config
                 if (line.empty() || line[0] == ';' || line[0] == '#') {
                     continue;
                 }
+                parsed.hadNonCommentContent = true;
 
                 if (line.front() == '[' && line.back() == ']') {
                     ImportedSection section{};
                     section.name = dualpad::input::ini::Trim(line.substr(1, line.size() - 2));
                     section.span = SourceSpan{ .path = path, .line = lineNo };
-                    sections.push_back(std::move(section));
-                    current = &sections.back();
+                    parsed.sections.push_back(std::move(section));
+                    current = &parsed.sections.back();
                     continue;
                 }
 
                 const auto eqPos = line.find('=');
                 if (eqPos == std::string::npos) {
-                    AddWarning(warnings, std::string("ini line missing '=' at ") + path.string() + ":" + std::to_string(lineNo));
+                    AddParseIssue(
+                        parsed,
+                        std::string("ini line missing '=' at ") + path.string() + ":" + std::to_string(lineNo),
+                        role == IniParseRole::Bindings);
                     continue;
                 }
 
                 if (!current) {
-                    AddWarning(warnings, std::string("ini entry without section at ") + path.string() + ":" + std::to_string(lineNo));
+                    AddParseIssue(
+                        parsed,
+                        std::string("ini entry without section at ") + path.string() + ":" + std::to_string(lineNo),
+                        role == IniParseRole::Bindings);
                     continue;
                 }
 
@@ -74,7 +125,26 @@ namespace dualpad::input_v2::config
                 current->entries.push_back(std::move(kv));
             }
 
-            return sections;
+            if (role == IniParseRole::Bindings && parsed.hadNonCommentContent && parsed.sections.empty()) {
+                AddParseIssue(
+                    parsed,
+                    std::string("bindings ini has content but no sections: ") + path.string(),
+                    true);
+            } else if (
+                role == IniParseRole::MenuPolicy &&
+                parsed.hadNonCommentContent &&
+                parsed.sections.empty()) {
+                AddParseIssue(
+                    parsed,
+                    std::string("menu policy ini has content but no sections; using default policy: ") + path.string(),
+                    false);
+            }
+
+            if (parsed.ok && !parsed.warnings.empty()) {
+                parsed.message = WarningSummary(parsed.warnings);
+            }
+
+            return parsed;
         }
 
         void CompileMenuPolicyAst(
@@ -145,19 +215,38 @@ namespace dualpad::input_v2::config
             result.bundle.bindingsMissing = true;
         } else {
             // Parse bindings ini into raw AST (no trigger/action lowering here).
-            result.bundle.bindings.sections = ParseIniFile(result.bundle.bindingsPath, result.bundle.warnings);
+            auto parsed = ParseIniFile(result.bundle.bindingsPath, IniParseRole::Bindings);
+            result.bundle.warnings.insert(
+                result.bundle.warnings.end(),
+                parsed.warnings.begin(),
+                parsed.warnings.end());
+            if (!parsed.ok) {
+                result.ok = false;
+                result.message = parsed.message;
+                return result;
+            }
+            result.bundle.bindings.sections = std::move(parsed.sections);
         }
 
         if (!std::filesystem::exists(result.bundle.menuPolicyPath)) {
             result.bundle.menuPolicyMissing = true;
         } else {
-            const auto sections = ParseIniFile(result.bundle.menuPolicyPath, result.bundle.warnings);
-            CompileMenuPolicyAst(result.bundle.menuPolicyPath, sections, result.bundle.menuPolicy);
+            auto parsed = ParseIniFile(result.bundle.menuPolicyPath, IniParseRole::MenuPolicy);
+            result.bundle.warnings.insert(
+                result.bundle.warnings.end(),
+                parsed.warnings.begin(),
+                parsed.warnings.end());
+            if (!parsed.ok) {
+                result.ok = false;
+                result.message = parsed.message;
+                return result;
+            }
+            CompileMenuPolicyAst(result.bundle.menuPolicyPath, parsed.sections, result.bundle.menuPolicy);
         }
 
         // Missing files are not an import failure; compile phase decides whether built-in defaults are allowed.
         result.ok = true;
-        result.message = "ok";
+        result.message = result.bundle.warnings.empty() ? "ok" : WarningSummary(result.bundle.warnings);
         return result;
     }
 }

--- a/src/input_v2/config/LegacyIniImporter.h
+++ b/src/input_v2/config/LegacyIniImporter.h
@@ -60,6 +60,7 @@ namespace dualpad::input_v2::config
         LegacyBindingsAst bindings;
         LegacyMenuPolicyAst menuPolicy;
 
+        // Non-fatal importer diagnostics that must remain visible to startup/reload callers.
         std::vector<std::string> warnings;
     };
 

--- a/tests/input_v2/AtomicConfigReloaderTests.cpp
+++ b/tests/input_v2/AtomicConfigReloaderTests.cpp
@@ -49,6 +49,11 @@ namespace
         std::getline(in, s, '\0');
         return s;
     }
+
+    bool Contains(std::string_view text, std::string_view needle)
+    {
+        return text.find(needle) != std::string_view::npos;
+    }
 }
 
 void RunAtomicConfigReloaderTests()
@@ -132,6 +137,18 @@ void RunAtomicConfigReloaderTests()
         Require(epoch.has_value() && *epoch == 2, "failed reload must keep active epoch");
     }
 
+    // Runtime reload with a syntactically broken existing config keeps existing active bundle.
+    {
+        WriteFile(bindings, "[Gameplay]\nButton:Cross Game.Jump\n");
+        const auto res = cfg::AtomicConfigReloader::GetSingleton().Reload();
+        Require(!res.ok, "reload with malformed bindings config should fail");
+        Require(
+            Contains(res.message, "missing '='"),
+            "reload import failure should expose malformed-line reason");
+        const auto epoch = cfg::AtomicConfigReloader::GetSingleton().GetActiveEpoch();
+        Require(epoch.has_value() && *epoch == 2, "failed malformed reload must keep active epoch");
+    }
+
     // Startup recovery uses disk last-known-good when config is invalid and no active bundle exists.
     {
         cfg::AtomicConfigReloader::GetSingleton().ResetForTests();
@@ -156,6 +173,28 @@ void RunAtomicConfigReloaderTests()
         cfg::AtomicConfigReloader::GetSingleton().ResetForTests();
         const auto res = cfg::AtomicConfigReloader::GetSingleton().LoadOrRecover(bindings2, policy2);
         Require(!res.ok, "startup must fail when config is invalid and no LKG exists");
+    }
+
+    // Startup with syntactically broken config and no disk LKG fails closed.
+    {
+        const auto tempBroken = std::filesystem::temp_directory_path() / "dualpad-inputv2-reloader-broken-no-lkg";
+        std::filesystem::remove_all(tempBroken);
+        std::filesystem::create_directories(tempBroken);
+
+        const auto bindingsBroken = tempBroken / "DualPadBindings.ini";
+        const auto policyBroken = tempBroken / "DualPadMenuPolicy.ini";
+        WriteFile(bindingsBroken, "[Gameplay]\nButton:Cross Game.Jump\n");
+        WriteFile(policyBroken, "[Policy]\nunknown_menu_policy=track\n");
+
+        cfg::AtomicConfigReloader::GetSingleton().ResetForTests();
+        const auto res = cfg::AtomicConfigReloader::GetSingleton().LoadOrRecover(bindingsBroken, policyBroken);
+        Require(!res.ok, "startup must fail closed when existing bindings config is malformed and no LKG exists");
+        Require(
+            Contains(res.message, "missing '='"),
+            "startup malformed config failure should expose malformed-line reason");
+        Require(
+            !cfg::AtomicConfigReloader::GetSingleton().GetActiveEpoch().has_value(),
+            "startup malformed config failure must not promote an active epoch");
     }
 
     // Startup with invalid config and stale/bad disk LKG fails closed.

--- a/tests/input_v2/LegacyIniImporterTests.cpp
+++ b/tests/input_v2/LegacyIniImporterTests.cpp
@@ -3,6 +3,7 @@
 #include "input_v2/config/LegacyIniImporter.h"
 
 #include <filesystem>
+#include <fstream>
 #include <stdexcept>
 #include <string_view>
 
@@ -31,6 +32,18 @@ namespace
             from = parent;
         }
         return std::filesystem::current_path();
+    }
+
+    void WriteFile(const std::filesystem::path& path, std::string_view contents)
+    {
+        std::filesystem::create_directories(path.parent_path());
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        out << contents;
+    }
+
+    bool Contains(std::string_view text, std::string_view needle)
+    {
+        return text.find(needle) != std::string_view::npos;
     }
 }
 
@@ -61,6 +74,45 @@ void RunLegacyIniImporterTests()
         Require(res.ok, "LegacyIniImporter::Import(missing) should still be ok");
         Require(res.bundle.bindingsMissing, "bindingsMissing should be true");
         Require(res.bundle.menuPolicyMissing, "menuPolicyMissing should be true");
+    }
+
+    {
+        const auto temp = std::filesystem::temp_directory_path() / "dualpad-inputv2-import-entry-before-section";
+        std::filesystem::remove_all(temp);
+        const auto badBindings = temp / "DualPadBindings.ini";
+        WriteFile(badBindings, "Button:Cross=Game.Jump\n");
+
+        const auto res = cfg::LegacyIniImporter::Import(badBindings, policy);
+        Require(!res.ok, "existing bindings file with entry before section must fail import");
+        Require(
+            Contains(res.message, "entry without section"),
+            "entry-before-section failure should be visible in import message");
+    }
+
+    {
+        const auto temp = std::filesystem::temp_directory_path() / "dualpad-inputv2-import-malformed-line";
+        std::filesystem::remove_all(temp);
+        const auto badBindings = temp / "DualPadBindings.ini";
+        WriteFile(badBindings, "[Gameplay]\nButton:Cross Game.Jump\n");
+
+        const auto res = cfg::LegacyIniImporter::Import(badBindings, policy);
+        Require(!res.ok, "existing bindings file with malformed line must fail import");
+        Require(
+            Contains(res.message, "missing '='"),
+            "malformed-line failure should be visible in import message");
+    }
+
+    {
+        const auto temp = std::filesystem::temp_directory_path() / "dualpad-inputv2-import-bindings-directory";
+        std::filesystem::remove_all(temp);
+        const auto bindingsDirectory = temp / "DualPadBindings.ini";
+        std::filesystem::create_directories(bindingsDirectory);
+
+        const auto res = cfg::LegacyIniImporter::Import(bindingsDirectory, policy);
+        Require(!res.ok, "existing bindings path that is a directory must fail import");
+        Require(
+            Contains(res.message, "failed to open ini"),
+            "unreadable bindings failure should be visible in import message");
     }
 }
 


### PR DESCRIPTION
## Summary
- fail closed when an existing bindings INI cannot be opened, has entries before any section, has malformed non-comment lines, or has content but no sections
- preserve missing-config startup defaults for the case where both primary config files are absent
- surface non-fatal menu policy parse warnings through importer/reloader messages and logs
- add B3 regression coverage for broken existing INI reload/startup paths

## Verification
- TDD red: `xmake build -y DualPadManifestCompilerTests; xmake run -y DualPadManifestCompilerTests` failed on `existing bindings file with entry before section must fail import`
- `xmake build -y DualPadManifestCompilerTests`
- `xmake run -y DualPadManifestCompilerTests`
- `powershell -ExecutionPolicy Bypass -File scripts/ci/run_rc_readiness.ps1 -ExpectCleanManifest`